### PR TITLE
feat: fix manifest calculating issue (BigInt)

### DIFF
--- a/scripts/cs2.ts
+++ b/scripts/cs2.ts
@@ -35,7 +35,7 @@ async function getLatestCsgoManifest() {
         );
         const matches = output.match(/Manifest\s(\d+)/);
         if (matches !== null) {
-            return parseInt(matches[1]);
+            return BigInt(matches[1]);
         }
     } catch (error) {
         console.error(error);
@@ -105,7 +105,7 @@ async function checkCsgoPackageDirectory() {
     if (!(await exists(workdirPath))) {
         await mkdir(workdirPath, { recursive: true });
     }
-    const manifest = (await exists(csgoManifestPath)) ? parseInt(await readFile(csgoManifestPath, "utf-8")) : 0;
+    const manifest = (await exists(csgoManifestPath)) ? BigInt(await readFile(csgoManifestPath, "utf-8")) : 0;
     const latestManifest = await getLatestCsgoManifest();
     if (latestManifest === undefined) {
         warning(`Failed to get latest manifest for depot ${DEPOT_ID}`);


### PR DESCRIPTION
Because of the way how numbers are calculated in JS, we can't directly compare big manifest numbers.
To demonstrate: if we insert the latest manifest number (according to https://steamdb.info/depot/2347770/ it's 3039074201558728829) into the browser console, we would get something like this:

![image](https://github.com/user-attachments/assets/1f5f7467-1aae-46d5-80d5-02257c968476)

To overcome this issue, we need to use BigInt, which will solve our problems and correctly calculate and compare big numbers.

This issue also occurs when calculating 64-bit SteamID's, but that's out of topic.