### PR TITLE
Fix Immortal item chance

### DIFF
--- a/src/economy-container.ts
+++ b/src/economy-container.ts
@@ -62,7 +62,7 @@ export const CS2RarityColorOrder = {
     [CS2RarityColor.Mythical]: 4,
     [CS2RarityColor.Legendary]: 5,
     [CS2RarityColor.Ancient]: 6,
-    [CS2RarityColor.Immortal]: 7
+    [CS2RarityColor.Immortal]: 6.55
 } as const;
 
 export const CS2_RARITY_COLOR_DEFAULT = 0;


### PR DESCRIPTION
The knive chance is currently 0.13%. It should be 0.26%.

I have uploaded a sheet to calculate.
https://docs.google.com/spreadsheets/d/1V6z0pHLvBt3dhypDQoyRX4KRucsOEMrpgNn5OAk8whk/edit?usp=sharing
![image](https://github.com/user-attachments/assets/81b15c05-94da-469c-9424-7a6ff77486f2)
