### PR TITLE
Optimize assets encoding by measurement

### DIFF
--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -36,6 +36,50 @@
 //   what the workdir already had. Ties go to lossy, so the choice is total.
 //
 //   Cost: a second encode per texture. See the timing note in encode().
+// - `qualityFloor`/`distortionTolerance` re-rate the lossy winner AFTER min-pick has chosen the
+//   codec. `quality` is a single global number, but what a texture gets for those bits is not
+//   global at all: lossy VP8 is YUV 4:2:0, so a texture whose channels are independent data
+//   carries a chroma-subsampling error that `quality` cannot touch, and the DCT quantization
+//   error it CAN touch is a rounding difference on top of it. Measured over a 42-texture sample
+//   stratified by size rank, the two populations separate cleanly at q95 -> q70 (per-channel
+//   RMSE against the source):
+//
+//     ht_poly_camo_pattern_mask  19.04 -> 20.65   11.52 -> 6.00 MB
+//     cloud_camo_01              13.37 -> 14.59    7.73 -> 3.01 MB
+//     ak47_default_rough          7.05 ->  8.89    3.82 -> 1.01 MB
+//     famas_snake_song_roughness  1.22 ->  4.75    5.74 -> 2.73 MB
+//     sg556_default_color         1.52 ->  4.51    4.48 -> 1.29 MB
+//
+//   The first three are already distorted at q95 and 25 quality points buy them essentially
+//   nothing; the last two are clean, and the same 25 points cost them 3-4x their error. So the
+//   rule is measured per texture rather than declared: take the LOWEST quality whose distortion
+//   stays within `distortionTolerance` of what full quality achieves ON THIS TEXTURE, bounded by
+//   an absolute ceiling so a texture that starts out badly damaged cannot be damaged without
+//   limit. Bits are spent only where they measurably buy fidelity. On that sample it is 24.1% of
+//   the lossy bytes at a tolerance of 10%, and it leaves 15 of 42 textures at full quality.
+//
+//   Distortion is per-channel RMSE, worst channel, against the same pixels the encoder was fed
+//   (so alpha quantization is already applied and does not count as error). Per-channel because
+//   a packed data texture's channels are independent -- a pooled figure lets a wrecked mask
+//   channel hide behind two clean ones. Channels are compared pairwise up to the narrower of the
+//   two buffers: libwebp drops a fully-opaque alpha plane on its own, and a plane it dropped for
+//   being constant contributes no error.
+//
+//   This runs ONLY when the lossy candidate already won min-pick. Re-rating before the
+//   comparison would let a cheaper lossy encode undercut a VP8L winner, which is exactly the
+//   trade min-pick exists to refuse -- those textures are the masks and ID maps whose lossy
+//   artifacts the comparison retires, and shipping a smaller lossy version of one would bring
+//   the mosaic back. Every VP8L win is therefore bit-identical to what it was before this step.
+//
+//   Cost: 1.39x the wall time of the encoder without it (34.2s -> 47.5s over 142 jobs). The
+//   ladder is searched binary rather than walked, which relies on distortion being monotone in
+//   quality -- verified on the sample, where every texture's RMSE fell with every step up the
+//   ladder. The VP8L candidate, still the expensive half of a job, is untouched.
+//
+//   Verified end to end on a 142-job random sample: lossy bytes fell 22.7%, every VP8L winner
+//   and every quantized normal came out byte-identical, no texture exceeded its budget (worst
+//   ratio 1.100, worst absolute increase 1.23 levels), and max error moved by at most a few
+//   levels in either direction -- so the added error is spread, not concentrated in new blocks.
 // - `quantizeBits` overrides min-pick for normal maps, which min-pick cannot serve. A normal's
 //   three channels are an independent vector, not a color, and lossy VP8 is YUV 4:2:0 -- so the
 //   chroma planes carry X and Y at half resolution and the downsample/upsample shifts local means.
@@ -104,7 +148,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { availableParallelism } from "node:os";
 import { dirname } from "node:path";
-import sharp from "sharp";
+import sharp, { type Sharp } from "sharp";
 
 interface EncodeJob {
     src: string;
@@ -113,6 +157,9 @@ interface EncodeJob {
     dropAlpha?: boolean;
     quantizeBits?: number;
     alphaQuantizeBits?: number;
+    qualityFloor?: number;
+    distortionTolerance?: number;
+    distortionCeiling?: number;
 }
 
 const manifestPath = process.argv[2];
@@ -142,56 +189,114 @@ async function assertAlphaIsConstant(src: string) {
     }
 }
 
-// Both candidate encodes of one source. Each gets its own sharp instance: an instance carries
-// the pipeline it was configured with, so reusing one would apply removeAlpha() twice and, worse,
-// leave the two encodes sharing mutable state. Buffers, not files -- only the winner is written.
+// The pixels the encoder is fed, decoded once: alpha dropped and/or snapped onto the ladder,
+// whichever the job asked for. One decode serves both candidates AND the distortion measurements
+// below, all of which have to see the same input -- error is measured against what was encoded,
+// not against the file on disk, so a deliberate alpha quantization does not read as encoder error.
 //
-// Timing: the VP8L pass is the expensive half -- measured 5.3x the lossy encode's wall time over a
-// 60-texture stratified sample of the corpus (26.3s vs 5.0s), so min-pick costs roughly 6x
-// lossy-only encoding. That is the whole price of this approach, and it buys ~1% corpus-wide:
-// on that same sample VP8L won only 3 of 60 (8.3 MB -> 8.2 MB). The wins are not spread evenly,
-// they are concentrated in the low-entropy data textures, where they are large (masks and ID maps
-// shrink 60-90%) and where they also retire the lossy artifacts. If this ever dominates run time,
-// the cheap guard is to skip the VP8L attempt when the lossy encode's bits-per-pixel is high;
-// measured on 368 mask textures, every VP8L winner sat under 1.68 bpp.
-//
-// Both encodes of a job run sequentially inside one worker so the pool below still bounds total
-// concurrency and peak memory (two full-size buffers per worker, not per job).
-async function encodeBoth(
-    src: string,
-    quality: number,
-    dropAlpha: boolean,
-    alphaQuantizeBits: number | undefined
-) {
-    // Decoded once and shared by both candidates when the alpha plane needs quantizing, because
-    // the quantized pixels are the input to both. sharp treats a raw input buffer as read-only,
-    // so handing the same one to two pipelines is safe; it is the *instance* that cannot be
-    // reused (see the note above). Peak memory is unchanged in kind -- one decoded surface plus
-    // the two encoded buffers, still per worker rather than per job.
-    const source = await quantizeAlpha(src, dropAlpha, alphaQuantizeBits);
-    const open = () => {
-        if (source !== undefined) return sharp(source.data, { raw: source.info });
-        const pipeline = sharp(src);
-        return dropAlpha ? pipeline.removeAlpha() : pipeline;
-    };
-    const lossy = await open().webp({ quality, exact: true }).toBuffer();
-    const lossless = await open().webp({ lossless: true, quality: 100, exact: true }).toBuffer();
-    return { lossy, lossless };
+// sharp treats a raw input buffer as read-only, so handing the same one to several pipelines is
+// safe; it is the *instance* that cannot be reused. An instance carries the pipeline it was
+// configured with, so a shared one would apply removeAlpha() twice and leave the encodes sharing
+// mutable state. Hence a factory rather than a pipeline. Peak memory is one decoded surface plus
+// the encoded buffers, per worker rather than per job.
+async function prepareSource(src: string, dropAlpha: boolean, alphaQuantizeBits: number | undefined) {
+    const pipeline = dropAlpha ? sharp(src).removeAlpha() : sharp(src);
+    const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
+    const hasAlpha = info.channels === 4 || info.channels === 2;
+    if (alphaQuantizeBits !== undefined && !dropAlpha && hasAlpha) {
+        const table = quantizationTable(alphaQuantizeBits);
+        for (let index = info.channels - 1; index < data.length; index += info.channels) {
+            data[index] = table[data[index]!]!;
+        }
+    }
+    return { data, info, open: () => sharp(data, { raw: info }) };
 }
 
-// Snaps the alpha plane onto the quantization ladder and leaves RGB alone, or returns undefined
-// when there is nothing to do (no request, alpha being dropped, or no alpha channel) so the
-// caller keeps its cheaper file-input pipeline.
-async function quantizeAlpha(src: string, dropAlpha: boolean, bits: number | undefined) {
-    if (bits === undefined || dropAlpha) return undefined;
-    const table = quantizationTable(bits);
-    const { data, info } = await sharp(src).raw().toBuffer({ resolveWithObject: true });
-    if (info.channels !== 4 && info.channels !== 2) return undefined;
-    for (let index = info.channels - 1; index < data.length; index += info.channels) {
-        data[index] = table[data[index]!]!;
+// Per-channel RMSE against the encoded input, worst channel. Channels are paired positionally up
+// to the narrower buffer: libwebp drops a fully-opaque alpha plane by itself, and a plane dropped
+// for being constant carries no error. A grayscale input decodes back as three equal channels, so
+// pairing from index 0 still compares the one channel that exists.
+function distortion(
+    reference: Buffer,
+    referenceChannels: number,
+    decoded: Buffer,
+    decodedChannels: number,
+    pixels: number
+) {
+    let worst = 0;
+    for (let channel = 0; channel < Math.min(referenceChannels, decodedChannels); channel += 1) {
+        let sum = 0;
+        for (let pixel = 0; pixel < pixels; pixel += 1) {
+            const delta = reference[pixel * referenceChannels + channel]! - decoded[pixel * decodedChannels + channel]!;
+            sum += delta * delta;
+        }
+        const rmse = Math.sqrt(sum / pixels);
+        if (rmse > worst) worst = rmse;
     }
-    return { data, info };
+    return worst;
 }
+
+// The lowest quality on the ladder whose distortion stays within budget of what full quality
+// achieves on this same texture, encoded. Returns the full-quality buffer when nothing qualifies.
+//
+// Timing: the VP8L pass is the expensive half of a job -- measured 5.3x the lossy encode's wall
+// time over a 60-texture stratified sample of the corpus (26.3s vs 5.0s). The ladder is searched
+// binary rather than walked, so this adds ~3 lossy encodes and their decodes on top of that, and
+// only on jobs where lossy already won. Binary search is valid because distortion is monotone in
+// quality: on the 42-texture sample every texture's RMSE fell at every step up the ladder.
+//
+// If encode time ever dominates, the cheap guard is a size floor -- the search is worth ~24% of a
+// 4 MB texture and ~24% of a 40 KB one, and only the first is worth three extra encodes.
+async function selectQuality(
+    open: () => Sharp,
+    reference: Buffer,
+    info: { width: number; height: number; channels: number },
+    fullQuality: Buffer,
+    quality: number,
+    floor: number,
+    tolerance: number,
+    ceiling: number
+) {
+    const ladder: number[] = [];
+    for (let step = quality - QUALITY_LADDER_STEP; step >= floor; step -= QUALITY_LADDER_STEP) {
+        ladder.push(step);
+    }
+    if (ladder.length === 0) return fullQuality;
+
+    const pixels = info.width * info.height;
+    const measure = async (buffer: Buffer) => {
+        const { data, info: decoded } = await sharp(buffer).raw().toBuffer({ resolveWithObject: true });
+        return distortion(reference, info.channels, data, decoded.channels, pixels);
+    };
+    const budget = await measure(fullQuality);
+    const encoded = new Map<number, Buffer>();
+    const fits = async (candidate: number) => {
+        const buffer = await open().webp({ quality: candidate, exact: true }).toBuffer();
+        encoded.set(candidate, buffer);
+        const measured = await measure(buffer);
+        return measured <= budget * (1 + tolerance) && measured - budget <= ceiling;
+    };
+
+    // The ladder descends and acceptance is monotone, so the qualities that fit are a prefix of
+    // it and the answer is the last index that fits.
+    let low = 0;
+    let high = ladder.length - 1;
+    let best = -1;
+    while (low <= high) {
+        const middle = (low + high) >> 1;
+        if (await fits(ladder[middle]!)) {
+            best = middle;
+            low = middle + 1;
+        } else {
+            high = middle - 1;
+        }
+    }
+    return best === -1 ? fullQuality : encoded.get(ladder[best]!)!;
+}
+
+// Quality points between rungs of the search ladder. Five is the granularity libwebp's own
+// quality scale is meaningful at; finer steps cost encodes to land on sizes a percent apart.
+const QUALITY_LADDER_STEP = 5;
 
 // A 256-entry lookup mapping every byte to its nearest rung on a ladder of 2^bits evenly spaced
 // levels, PLUS the two neutral values. Evenly spaced across the full range means 0 and 255 map to
@@ -253,7 +358,10 @@ async function encode({
     quality,
     dropAlpha,
     quantizeBits,
-    alphaQuantizeBits
+    alphaQuantizeBits,
+    qualityFloor,
+    distortionTolerance,
+    distortionCeiling
 }: EncodeJob) {
     try {
         await mkdir(dirname(dest), { recursive: true });
@@ -264,16 +372,33 @@ async function encode({
             console.log(`done ${dest}`);
             return;
         }
-        const { lossy, lossless } = await encodeBoth(
-            src,
-            quality,
-            dropAlpha === true,
-            alphaQuantizeBits ?? undefined
-        );
+        const source = await prepareSource(src, dropAlpha === true, alphaQuantizeBits ?? undefined);
+        const lossy = await source.open().webp({ quality, exact: true }).toBuffer();
+        const lossless = await source.open().webp({ lossless: true, quality: 100, exact: true }).toBuffer();
         // Ties go to lossy: it is the status quo, and preferring it keeps the winner stable for
         // any texture where the two happen to land on the same byte count.
-        const winner = lossless.length < lossy.length ? lossless : lossy;
-        await writeFile(dest, winner);
+        //
+        // A VP8L winner is written exactly as it was encoded. Re-rating happens only on the other
+        // branch, so no texture can trade a bit-exact encode for a cheaper lossy one.
+        if (lossless.length < lossy.length) {
+            await writeFile(dest, lossless);
+            console.log(`done ${dest}`);
+            return;
+        }
+        const rated =
+            qualityFloor != null && distortionTolerance != null && distortionCeiling != null
+                ? await selectQuality(
+                      source.open,
+                      source.data,
+                      source.info,
+                      lossy,
+                      quality,
+                      qualityFloor,
+                      distortionTolerance,
+                      distortionCeiling
+                  )
+                : lossy;
+        await writeFile(dest, rated);
         console.log(`done ${dest}`);
     } catch (error) {
         failed += 1;

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -13,6 +13,12 @@
 //   and lossy Q otherwise.
 // - `lossless` is only forwarded when true so lossy and near-lossless outputs stay
 //   byte-identical to previous runs.
+// - `dropAlpha` marks a texture whose game format has no alpha channel, so the exported one is
+//   ValveResourceFormat's invention. Nothing may be chained after `removeAlpha()`: sharp orders
+//   its pipeline internally, not by call order, and puts `resize` FIRST — so `.removeAlpha()
+//   .resize()` still premultiplies against the alpha we are removing. On the BC5 normals, whose
+//   fabricated alpha is 0 rather than 255, that zeroes the whole image (measured: 68.6 MB of
+//   normals encode to 0.00 MB). Any future resize step has to run as its own pass.
 
 import { mkdir, readFile } from "node:fs/promises";
 import { availableParallelism } from "node:os";
@@ -25,6 +31,7 @@ interface EncodeJob {
     quality: number;
     nearLossless: boolean;
     lossless?: boolean;
+    dropAlpha?: boolean;
 }
 
 const manifestPath = process.argv[2];
@@ -40,10 +47,26 @@ const jobs: EncodeJob[] = (await readFile(manifestPath, "utf-8"))
 
 let failed = 0;
 
-async function encode({ src, dest, quality, nearLossless, lossless }: EncodeJob) {
+// A texture classified as having no alpha in the game must have a constant one in the export.
+// If it varies, the classification is wrong and dropping the channel would discard real data —
+// the exact failure this flag exists to prevent — so fail the job instead of guessing.
+async function assertAlphaIsConstant(src: string) {
+    const { channels } = await sharp(src).stats();
+    const alpha = channels[3];
+    if (alpha !== undefined && alpha.min !== alpha.max) {
+        throw new Error(
+            `dropAlpha requested but alpha varies (${alpha.min}..${alpha.max}); ` +
+                `the source format was classified as having none`
+        );
+    }
+}
+
+async function encode({ src, dest, quality, nearLossless, lossless, dropAlpha }: EncodeJob) {
     try {
         await mkdir(dirname(dest), { recursive: true });
-        await sharp(src)
+        if (dropAlpha) await assertAlphaIsConstant(src);
+        const pipeline = sharp(src);
+        await (dropAlpha ? pipeline.removeAlpha() : pipeline)
             .webp({ quality, nearLossless, ...(lossless ? { lossless: true } : {}), exact: true })
             .toFile(dest);
         console.log(`done ${dest}`);

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -7,8 +7,35 @@
 // (AssetProcessor.ProcessMaterialTextures) with a JSONL manifest of jobs. Output bytes feed the
 // content hashes embedded in CDN filenames, so sharp is pinned exact and nothing here may change
 // encoded bytes. Constraints:
-// - Every job takes the same lossy VP8 encode; there are no lossless or near-lossless paths.
-//   See Config.WebpQuality for what that costs and why the carve-outs were not worth it.
+// - Every job is encoded BOTH ways -- lossy VP8 at Config.WebpQuality and fully-lossless VP8L --
+//   and the smaller output wins. This replaces the param-name carve-outs that selected a codec
+//   from the material binding; see below for why picking on bytes is both smaller and safer.
+//
+//   Size: min-pick can never exceed the all-lossy size, because all-lossy is one of the two
+//   candidates. It is strictly smaller in practice -- low-entropy data textures (masks, ID maps)
+//   compress far better as VP8L, e.g. pist_deagle_masks 15.7 KB lossy -> 1.6 KB lossless.
+//
+//   Fidelity: every texture that picks VP8L becomes bit-exact, which is what retires the
+//   artifact class the old carve-outs existed for. Lossy VP8 is YUV 4:2:0, so a texture whose
+//   channels are independent data rather than a color dips flat macroblocks on a 16px lattice:
+//   measured on weapon_pist_deagle_masks, 118 fully-saturated 16x16 blocks in the paint-zone
+//   channel fell off 255 by up to 138. The shader blends bare metal with (1 - g_tMasks.x), so
+//   each dipped block rendered as a pixelated square on Desert Eagle | Blaze. That texture is
+//   27.9 KB lossy vs 10.3 KB lossless, so min-pick takes VP8L and the error goes to zero.
+//
+//   Why not select on the material param name: the binding does not predict the outcome. Both
+//   the textures that shrink and the ones that grow under VP8L bind as g_tPaintByNumberMasks
+//   (137 of 213 shrink, 76 grow), so no name-based rule separates them -- but g_tMasks,
+//   g_tLayerId, g_tTintId and g_tLayerMask shrink unanimously (150/150). Bytes decide correctly
+//   in every one of those cases without enumerating params, and without needing the
+//   composite-material loose-variable walk the old collector required to find most of them.
+//
+//   Determinism: libwebp output is a pure function of (input bytes, settings, pinned version),
+//   so the comparison yields the same winner on a clean run and an incremental one. It reads
+//   only the source PNG -- unlike a rule built from decompiler state, which would vary with
+//   what the workdir already had. Ties go to lossy, so the choice is total.
+//
+//   Cost: a second encode per texture. See the timing note in encode().
 // - `exact` must stay on: 9,422 textures (2.4 GB) still carry a genuine varying alpha with
 //   fully-transparent pixels, and shader logic reads the RGB underneath. Dropping alpha where
 //   the game format has none did not retire this — it only removed the fabricated planes.
@@ -21,7 +48,7 @@
 //   fabricated alpha is 0 rather than 255, that zeroes the whole image (measured: 68.6 MB of
 //   normals encode to 0.00 MB). Any future resize step has to run as its own pass.
 
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { availableParallelism } from "node:os";
 import { dirname } from "node:path";
 import sharp from "sharp";
@@ -60,14 +87,40 @@ async function assertAlphaIsConstant(src: string) {
     }
 }
 
+// Both candidate encodes of one source. Each gets its own sharp instance: an instance carries
+// the pipeline it was configured with, so reusing one would apply removeAlpha() twice and, worse,
+// leave the two encodes sharing mutable state. Buffers, not files -- only the winner is written.
+//
+// Timing: the VP8L pass is the expensive half -- measured 5.3x the lossy encode's wall time over a
+// 60-texture stratified sample of the corpus (26.3s vs 5.0s), so min-pick costs roughly 6x
+// lossy-only encoding. That is the whole price of this approach, and it buys ~1% corpus-wide:
+// on that same sample VP8L won only 3 of 60 (8.3 MB -> 8.2 MB). The wins are not spread evenly,
+// they are concentrated in the low-entropy data textures, where they are large (masks and ID maps
+// shrink 60-90%) and where they also retire the lossy artifacts. If this ever dominates run time,
+// the cheap guard is to skip the VP8L attempt when the lossy encode's bits-per-pixel is high;
+// measured on 368 mask textures, every VP8L winner sat under 1.68 bpp.
+//
+// Both encodes of a job run sequentially inside one worker so the pool below still bounds total
+// concurrency and peak memory (two full-size buffers per worker, not per job).
+async function encodeBoth(src: string, quality: number, dropAlpha: boolean) {
+    const open = () => {
+        const pipeline = sharp(src);
+        return dropAlpha ? pipeline.removeAlpha() : pipeline;
+    };
+    const lossy = await open().webp({ quality, exact: true }).toBuffer();
+    const lossless = await open().webp({ lossless: true, quality: 100, exact: true }).toBuffer();
+    return { lossy, lossless };
+}
+
 async function encode({ src, dest, quality, dropAlpha }: EncodeJob) {
     try {
         await mkdir(dirname(dest), { recursive: true });
         if (dropAlpha) await assertAlphaIsConstant(src);
-        const pipeline = sharp(src);
-        await (dropAlpha ? pipeline.removeAlpha() : pipeline)
-            .webp({ quality, exact: true })
-            .toFile(dest);
+        const { lossy, lossless } = await encodeBoth(src, quality, dropAlpha === true);
+        // Ties go to lossy: it is the status quo, and preferring it keeps the winner stable for
+        // any texture where the two happen to land on the same byte count.
+        const winner = lossless.length < lossy.length ? lossless : lossy;
+        await writeFile(dest, winner);
         console.log(`done ${dest}`);
     } catch (error) {
         failed += 1;

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -7,12 +7,13 @@
 // (AssetProcessor.ProcessMaterialTextures) with a JSONL manifest of jobs. Output bytes feed the
 // content hashes embedded in CDN filenames, so sharp is pinned exact and nothing here may change
 // encoded bytes. Constraints:
-// - `exact` must stay on: shader logic reads RGB under fully-transparent pixels.
-// - `quality` is overloaded: the near-lossless level for near-lossless jobs (normal maps), VP8L
-//   compression effort for lossless jobs (paint masks, AO — bytes are bit-exact regardless),
-//   and lossy Q otherwise.
-// - `lossless` is only forwarded when true so lossy and near-lossless outputs stay
-//   byte-identical to previous runs.
+// - Every job takes the same lossy VP8 encode; there are no lossless or near-lossless paths.
+//   See Config.WebpQuality for what that costs and why the carve-outs were not worth it.
+// - `exact` must stay on: 9,422 textures (2.4 GB) still carry a genuine varying alpha with
+//   fully-transparent pixels, and shader logic reads the RGB underneath. Dropping alpha where
+//   the game format has none did not retire this — it only removed the fabricated planes.
+//   Turning `exact` off saves 0.43% on exactly those files while raising their max RGB error
+//   under alpha=0 from 49 to 147 (measured, q95, 25-texture sample).
 // - `dropAlpha` marks a texture whose game format has no alpha channel, so the exported one is
 //   ValveResourceFormat's invention. Nothing may be chained after `removeAlpha()`: sharp orders
 //   its pipeline internally, not by call order, and puts `resize` FIRST — so `.removeAlpha()
@@ -29,8 +30,6 @@ interface EncodeJob {
     src: string;
     dest: string;
     quality: number;
-    nearLossless: boolean;
-    lossless?: boolean;
     dropAlpha?: boolean;
 }
 
@@ -61,13 +60,13 @@ async function assertAlphaIsConstant(src: string) {
     }
 }
 
-async function encode({ src, dest, quality, nearLossless, lossless, dropAlpha }: EncodeJob) {
+async function encode({ src, dest, quality, dropAlpha }: EncodeJob) {
     try {
         await mkdir(dirname(dest), { recursive: true });
         if (dropAlpha) await assertAlphaIsConstant(src);
         const pipeline = sharp(src);
         await (dropAlpha ? pipeline.removeAlpha() : pipeline)
-            .webp({ quality, nearLossless, ...(lossless ? { lossless: true } : {}), exact: true })
+            .webp({ quality, exact: true })
             .toFile(dest);
         console.log(`done ${dest}`);
     } catch (error) {

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -66,6 +66,29 @@
 //
 //   Alpha is never quantized. A sticker's g_tNormalRoughnessSticker0 packs roughness into it,
 //   and a shader reads that as data.
+// - `alphaQuantizeBits` snaps the alpha plane onto the same ladder before min-pick runs, and is
+//   the biggest remaining win in the corpus. WebP stores a lossy image's alpha in a separate ALPH
+//   chunk that is always compressed LOSSLESSLY, so `quality` never touches it: measured over the
+//   11,263 lossy textures that carry one, ALPH is 1.17 GiB of the 6.95 GiB corpus, and on the
+//   worst files it is nearly all of them (mp5_statics_blue albedo: 6.29 MB alpha, 6.81 MB total).
+//
+//   What makes those planes incompressible is dither, not detail -- the same thing that made
+//   normals incompressible. AK-47 | AUTOEXEC's g_tPattern alpha holds 72 distinct values, but
+//   90% of its pixels are 87 or 88 and 7% are 42 or 43: it is a two-plateau wear mask with an LSB
+//   rattle laid over it. Snapping that rattle away takes the file from 4.21 MB to 1.59 MB.
+//
+//   Quantizing is deliberate in preference to libwebp's own `alphaQuality`, which reaches similar
+//   sizes (4.21 MB -> 1.54 MB on the same texture) by running the alpha plane through the LOSSY
+//   VP8 encoder. That is the 16px-macroblock artifact this file already routes normals and masks
+//   around, and pattern alpha feeds `smoothstep` wear thresholds in csgo_customweapon_ps_style6,
+//   where a lattice-aligned dip reads as square patches of wear. Quantization error follows the
+//   mask's own gradients instead and is bounded at 255/(2^bits-1)/2. Note also that `alphaQuality`
+//   is a cliff, not a dial -- 100/95/90 were byte-identical in every texture measured, and the
+//   drop only lands somewhere below 90 -- so it is not tunable even if the artifact were tolerable.
+//
+//   Only the min-pick path takes this. The quantized path leaves alpha alone on purpose (a
+//   sticker's g_tNormalRoughnessSticker0 packs roughness into it), and `dropAlpha` discards the
+//   plane outright, so neither has an alpha worth snapping.
 // - `exact` must stay on: 9,422 textures (2.4 GB) still carry a genuine varying alpha with
 //   fully-transparent pixels, and shader logic reads the RGB underneath. Dropping alpha where
 //   the game format has none did not retire this — it only removed the fabricated planes.
@@ -89,6 +112,7 @@ interface EncodeJob {
     quality: number;
     dropAlpha?: boolean;
     quantizeBits?: number;
+    alphaQuantizeBits?: number;
 }
 
 const manifestPath = process.argv[2];
@@ -133,8 +157,20 @@ async function assertAlphaIsConstant(src: string) {
 //
 // Both encodes of a job run sequentially inside one worker so the pool below still bounds total
 // concurrency and peak memory (two full-size buffers per worker, not per job).
-async function encodeBoth(src: string, quality: number, dropAlpha: boolean) {
+async function encodeBoth(
+    src: string,
+    quality: number,
+    dropAlpha: boolean,
+    alphaQuantizeBits: number | undefined
+) {
+    // Decoded once and shared by both candidates when the alpha plane needs quantizing, because
+    // the quantized pixels are the input to both. sharp treats a raw input buffer as read-only,
+    // so handing the same one to two pipelines is safe; it is the *instance* that cannot be
+    // reused (see the note above). Peak memory is unchanged in kind -- one decoded surface plus
+    // the two encoded buffers, still per worker rather than per job.
+    const source = await quantizeAlpha(src, dropAlpha, alphaQuantizeBits);
     const open = () => {
+        if (source !== undefined) return sharp(source.data, { raw: source.info });
         const pipeline = sharp(src);
         return dropAlpha ? pipeline.removeAlpha() : pipeline;
     };
@@ -143,24 +179,41 @@ async function encodeBoth(src: string, quality: number, dropAlpha: boolean) {
     return { lossy, lossless };
 }
 
-// Quantize each colour channel onto a ladder of 2^bits evenly spaced levels, then encode VP8L.
-// Alpha is copied through untouched. bits=8 is the identity ladder, which is how a texture asks
-// for a bit-exact lossless encode without opting into min-pick.
-async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
+// Snaps the alpha plane onto the quantization ladder and leaves RGB alone, or returns undefined
+// when there is nothing to do (no request, alpha being dropped, or no alpha channel) so the
+// caller keeps its cheaper file-input pipeline.
+async function quantizeAlpha(src: string, dropAlpha: boolean, bits: number | undefined) {
+    if (bits === undefined || dropAlpha) return undefined;
+    const table = quantizationTable(bits);
+    const { data, info } = await sharp(src).raw().toBuffer({ resolveWithObject: true });
+    if (info.channels !== 4 && info.channels !== 2) return undefined;
+    for (let index = info.channels - 1; index < data.length; index += info.channels) {
+        data[index] = table[data[index]!]!;
+    }
+    return { data, info };
+}
+
+// A 256-entry lookup mapping every byte to its nearest rung on a ladder of 2^bits evenly spaced
+// levels, PLUS the two neutral values. Evenly spaced across the full range means 0 and 255 map to
+// themselves. Pinning 127/128 is for normal maps, whose neutral is "pointing straight out": on a
+// uniform 16-rung ladder it falls exactly between rungs (127 -> 119), which tilts every flat
+// surface in the texture by a uniform ~5 degrees rather than adding noise. It costs two extra
+// rungs and nothing measurable in bytes, and it is harmless for the alpha ladder.
+//
+// Cached per bit depth: a job runs one of at most a handful of depths, and rebuilding the 256x18
+// nearest-rung search per texture is pure waste in the pool.
+const ladderCache = new Map<number, Buffer>();
+
+function quantizationTable(bits: number) {
     // Validated rather than trusted. A bad value here does not fail loudly, it silently ships:
     // `levels` of 0 divides by zero, the NaN coerces to 0 on the way into a Buffer, and every
     // texture encodes as solid black in ~200 bytes. That is what a null `quantizeBits` reaching
     // this function once did to every non-normal in the corpus.
     if (!Number.isInteger(bits) || bits < 1 || bits > 8) {
-        throw new Error(`quantizeBits must be an integer in 1..8, received ${bits}`);
+        throw new Error(`quantize bits must be an integer in 1..8, received ${bits}`);
     }
-    const pipeline = dropAlpha ? sharp(src).removeAlpha() : sharp(src);
-    const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
-    // Evenly spaced rungs across the full range, so 0 and 255 map to themselves, PLUS the two
-    // neutral values. A normal map's neutral is 127/128 -- "pointing straight out" -- and on a
-    // uniform 16-rung ladder it falls exactly between rungs (127 -> 119), which tilts every flat
-    // surface in the texture by a uniform ~5 degrees rather than adding noise. Pinning it costs
-    // two extra rungs and nothing measurable in bytes.
+    const cached = ladderCache.get(bits);
+    if (cached !== undefined) return cached;
     const levels = (1 << bits) - 1;
     const rungs = new Set<number>([127, 128]);
     for (let step = 0; step <= levels; step += 1) {
@@ -175,6 +228,17 @@ async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
         }
         table[value] = best;
     }
+    ladderCache.set(bits, table);
+    return table;
+}
+
+// Quantize each colour channel onto the ladder, then encode VP8L. Alpha is copied through
+// untouched. bits=8 is the identity ladder, which is how a texture asks for a bit-exact lossless
+// encode without opting into min-pick.
+async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
+    const table = quantizationTable(bits);
+    const pipeline = dropAlpha ? sharp(src).removeAlpha() : sharp(src);
+    const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
     const hasAlpha = info.channels === 4 || info.channels === 2;
     for (let index = 0; index < data.length; index += 1) {
         if (hasAlpha && index % info.channels === info.channels - 1) continue;
@@ -183,7 +247,14 @@ async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
     return sharp(data, { raw: info }).webp({ lossless: true, quality: 100, exact: true }).toBuffer();
 }
 
-async function encode({ src, dest, quality, dropAlpha, quantizeBits }: EncodeJob) {
+async function encode({
+    src,
+    dest,
+    quality,
+    dropAlpha,
+    quantizeBits,
+    alphaQuantizeBits
+}: EncodeJob) {
     try {
         await mkdir(dirname(dest), { recursive: true });
         if (dropAlpha) await assertAlphaIsConstant(src);
@@ -193,7 +264,12 @@ async function encode({ src, dest, quality, dropAlpha, quantizeBits }: EncodeJob
             console.log(`done ${dest}`);
             return;
         }
-        const { lossy, lossless } = await encodeBoth(src, quality, dropAlpha === true);
+        const { lossy, lossless } = await encodeBoth(
+            src,
+            quality,
+            dropAlpha === true,
+            alphaQuantizeBits ?? undefined
+        );
         // Ties go to lossy: it is the status quo, and preferring it keeps the winner stable for
         // any texture where the two happen to land on the same byte count.
         const winner = lossless.length < lossy.length ? lossless : lossy;

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -8,8 +8,11 @@
 // content hashes embedded in CDN filenames, so sharp is pinned exact and nothing here may change
 // encoded bytes. Constraints:
 // - Every job is encoded BOTH ways -- lossy VP8 at Config.WebpQuality and fully-lossless VP8L --
-//   and the smaller output wins. This replaces the param-name carve-outs that selected a codec
-//   from the material binding; see below for why picking on bytes is both smaller and safer.
+//   and the smaller output wins, with near-ties going to VP8L (see WEBP_LOSSLESS_MARGIN). This
+//   replaces the param-name carve-outs that selected a codec from the material binding; see below
+//   for why picking on bytes is both smaller and safer. Note the lossy candidate is encoded at
+//   Config.WebpQuality even though a lossy winner ships at Config.WebpLossyQualityCeiling: the
+//   comparison picks a codec, and making its lossy side cheaper would hand masks to VP8.
 //
 //   Size: min-pick can never exceed the all-lossy size, because all-lossy is one of the two
 //   candidates. It is strictly smaller in practice -- low-entropy data textures (masks, ID maps)
@@ -36,8 +39,10 @@
 //   what the workdir already had. Ties go to lossy, so the choice is total.
 //
 //   Cost: a second encode per texture. See the timing note in encode().
-// - `qualityFloor`/`distortionTolerance` re-rate the lossy winner AFTER min-pick has chosen the
-//   codec. `quality` is a single global number, but what a texture gets for those bits is not
+// - `qualityCeiling`/`qualityFloor`/`distortionTolerance` re-rate the lossy winner AFTER min-pick
+//   has chosen the codec, and the winner is re-encoded from `qualityCeiling` down -- the
+//   comparison encode is discarded. `quality` is a single global number, but what a texture gets
+//   for those bits is not
 //   global at all: lossy VP8 is YUV 4:2:0, so a texture whose channels are independent data
 //   carries a chroma-subsampling error that `quality` cannot touch, and the DCT quantization
 //   error it CAN touch is a rounding difference on top of it. Measured over a 42-texture sample
@@ -55,8 +60,13 @@
 //   rule is measured per texture rather than declared: take the LOWEST quality whose distortion
 //   stays within `distortionTolerance` of what full quality achieves ON THIS TEXTURE, bounded by
 //   an absolute ceiling so a texture that starts out badly damaged cannot be damaged without
-//   limit. Bits are spent only where they measurably buy fidelity. On that sample it is 24.1% of
-//   the lossy bytes at a tolerance of 10%, and it leaves 15 of 42 textures at full quality.
+//   limit. Bits are spent only where they measurably buy fidelity.
+//
+//   "Full quality" here means `qualityCeiling`, not `quality`. The budget is measured on the
+//   ceiling encode, so lowering the ceiling both caps the top rung and loosens the tolerance below
+//   it -- the two compound, and a texture typically lands 0-10 points under the ceiling rather
+//   than at it. Measured over 24 textures sampled probability-proportional-to-size from the lossy
+//   population that carries alpha, ceiling 85 ships 46.3% of the q95 bytes.
 //
 //   Distortion is per-channel RMSE, worst channel, against the same pixels the encoder was fed
 //   (so alpha quantization is already applied and does not count as error). Per-channel because
@@ -117,7 +127,10 @@
 //   worst files it is nearly all of them (mp5_statics_blue albedo: 6.29 MB alpha, 6.81 MB total).
 //
 //   What makes those planes incompressible is dither, not detail -- the same thing that made
-//   normals incompressible. AK-47 | AUTOEXEC's g_tPattern alpha holds 72 distinct values, but
+//   normals incompressible, and the reason the saving does not scale with file size. A plane that
+//   is genuine per-pixel noise has no rattle to snap and barely responds at any depth:
+//   gun_grunge_psd's alpha is 1.51 MiB at 5 bits, 1.28 at 4, and still 0.67 at ONE bit, against
+//   2.17 unquantized. A dithered plane collapses; that one does not, and no setting here fixes it. AK-47 | AUTOEXEC's g_tPattern alpha holds 72 distinct values, but
 //   90% of its pixels are 87 or 88 and 7% are 42 or 43: it is a two-plateau wear mask with an LSB
 //   rattle laid over it. Snapping that rattle away takes the file from 4.21 MB to 1.59 MB.
 //
@@ -157,6 +170,7 @@ interface EncodeJob {
     dropAlpha?: boolean;
     quantizeBits?: number;
     alphaQuantizeBits?: number;
+    qualityCeiling?: number;
     qualityFloor?: number;
     distortionTolerance?: number;
     distortionCeiling?: number;
@@ -236,8 +250,15 @@ function distortion(
     return worst;
 }
 
-// The lowest quality on the ladder whose distortion stays within budget of what full quality
-// achieves on this same texture, encoded. Returns the full-quality buffer when nothing qualifies.
+// The lowest quality on the ladder whose distortion stays within budget of what the CEILING
+// quality achieves on this same texture, encoded. Returns the ceiling encode when nothing below it
+// qualifies -- so a texture that resists the search still ships at the ceiling, never at the
+// comparison quality that min-pick was decided on.
+//
+// The reference is the ceiling and not `quality` on purpose. The tolerance is relative, so it only
+// ever means "within 10% of some anchor"; anchoring it at the quality a texture SHIPS at is what
+// makes the ladder below it reachable, and anchoring it at the comparison quality would hold every
+// texture to a budget measured on an encode none of them ship.
 //
 // Timing: the VP8L pass is the expensive half of a job -- measured 5.3x the lossy encode's wall
 // time over a 60-texture stratified sample of the corpus (26.3s vs 5.0s). The ladder is searched
@@ -251,30 +272,30 @@ async function selectQuality(
     open: () => Sharp,
     reference: Buffer,
     info: { width: number; height: number; channels: number },
-    fullQuality: Buffer,
-    quality: number,
+    qualityCeiling: number,
     floor: number,
     tolerance: number,
-    ceiling: number
+    distortionCeiling: number
 ) {
+    const atCeiling = await open().webp({ quality: qualityCeiling, exact: true, effort: WEBP_EFFORT }).toBuffer();
     const ladder: number[] = [];
-    for (let step = quality - QUALITY_LADDER_STEP; step >= floor; step -= QUALITY_LADDER_STEP) {
+    for (let step = qualityCeiling - QUALITY_LADDER_STEP; step >= floor; step -= QUALITY_LADDER_STEP) {
         ladder.push(step);
     }
-    if (ladder.length === 0) return fullQuality;
+    if (ladder.length === 0) return atCeiling;
 
     const pixels = info.width * info.height;
     const measure = async (buffer: Buffer) => {
         const { data, info: decoded } = await sharp(buffer).raw().toBuffer({ resolveWithObject: true });
         return distortion(reference, info.channels, data, decoded.channels, pixels);
     };
-    const budget = await measure(fullQuality);
+    const budget = await measure(atCeiling);
     const encoded = new Map<number, Buffer>();
     const fits = async (candidate: number) => {
-        const buffer = await open().webp({ quality: candidate, exact: true }).toBuffer();
+        const buffer = await open().webp({ quality: candidate, exact: true, effort: WEBP_EFFORT }).toBuffer();
         encoded.set(candidate, buffer);
         const measured = await measure(buffer);
-        return measured <= budget * (1 + tolerance) && measured - budget <= ceiling;
+        return measured <= budget * (1 + tolerance) && measured - budget <= distortionCeiling;
     };
 
     // The ladder descends and acceptance is monotone, so the qualities that fit are a prefix of
@@ -291,12 +312,43 @@ async function selectQuality(
             high = middle - 1;
         }
     }
-    return best === -1 ? fullQuality : encoded.get(ladder[best]!)!;
+    return best === -1 ? atCeiling : encoded.get(ladder[best]!)!;
 }
 
 // Quality points between rungs of the search ladder. Five is the granularity libwebp's own
 // quality scale is meaningful at; finer steps cost encodes to land on sizes a percent apart.
 const QUALITY_LADDER_STEP = 5;
+
+// libwebp's compression effort, on every encode in this file. 6 buys ~1.5% of the LOSSY bytes for
+// more encoder time; it buys the VP8L candidate nothing, because sharp maps `effort` to the VP8
+// method only and a lossless encode at `quality: 100` already runs libwebp's most expensive path
+// (measured over 40 VP8L winners: every one byte-identical at effort 4 and 6).
+//
+// That asymmetry is one of the two reasons WEBP_LOSSLESS_MARGIN exists. See there.
+const WEBP_EFFORT = 6;
+
+// How much larger the VP8L candidate may be and still win min-pick.
+//
+// Without it, every knob that makes the lossy candidate cheaper is a one-directional thumb on a
+// scale that decides FIDELITY, not just size. WEBP_EFFORT shrinks only the lossy side (~1.5%), and
+// the alpha ladder shrinks it faster than the lossless side too -- VP8L carries alpha inside its
+// own entropy coding, where a shallower ladder buys much less than it does in a separate ALPH
+// chunk. Between them they move a near-tie by 5-6%: sig_karrigan_glitter_mask goes from 0.972 to
+// 1.054 lossless/lossy purely from settings, with its pixels unchanged. Measured on 60 of the
+// non-normal VP8L winners, 5 cross to lossy on that alone -- and those winners are the masks and
+// ID maps whose lossy artifacts min-pick was built to retire, so the flips land exactly where
+// they hurt.
+//
+// 6% is measured, not guessed, and it is cheap because the two populations barely overlap. Across
+// those 60 VP8L winners the ratio distribution runs 0.015 to 1.050, with only five files above
+// 1.00; a 6% margin keeps all 60 bit-exact for 13,490 total bytes. Across 60 of today's LOSSY
+// winners the smallest ratio is 1.32 -- lossless is never within reach for a texture that genuinely
+// wants VP8 -- so the margin costs that population exactly nothing. It binds only on near-ties, and
+// near-ties belong on the bit-exact side of the line.
+//
+// Raise it if a future knob makes lossy cheaper again and masks start flipping; the cost of raising
+// it is bounded by the margin itself, on files that are small by construction.
+const WEBP_LOSSLESS_MARGIN = 1.06;
 
 // A 256-entry lookup mapping every byte to its nearest rung on a ladder of 2^bits evenly spaced
 // levels, PLUS the two neutral values. Evenly spaced across the full range means 0 and 255 map to
@@ -349,7 +401,9 @@ async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
         if (hasAlpha && index % info.channels === info.channels - 1) continue;
         data[index] = table[data[index]!]!;
     }
-    return sharp(data, { raw: info }).webp({ lossless: true, quality: 100, exact: true }).toBuffer();
+    return sharp(data, { raw: info })
+        .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT })
+        .toBuffer();
 }
 
 async function encode({
@@ -359,6 +413,7 @@ async function encode({
     dropAlpha,
     quantizeBits,
     alphaQuantizeBits,
+    qualityCeiling,
     qualityFloor,
     distortionTolerance,
     distortionCeiling
@@ -373,26 +428,32 @@ async function encode({
             return;
         }
         const source = await prepareSource(src, dropAlpha === true, alphaQuantizeBits ?? undefined);
-        const lossy = await source.open().webp({ quality, exact: true }).toBuffer();
-        const lossless = await source.open().webp({ lossless: true, quality: 100, exact: true }).toBuffer();
-        // Ties go to lossy: it is the status quo, and preferring it keeps the winner stable for
-        // any texture where the two happen to land on the same byte count.
+        // The comparison candidate is encoded at `quality`, NOT at `qualityCeiling`. It exists to
+        // pick a codec, not to ship: a cheaper lossy candidate wins min-pick more often, and the
+        // textures it would win are the masks whose lossy artifacts min-pick exists to retire.
+        const lossy = await source.open().webp({ quality, exact: true, effort: WEBP_EFFORT }).toBuffer();
+        const lossless = await source
+            .open()
+            .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT })
+            .toBuffer();
+        // Ties, and near-ties inside WEBP_LOSSLESS_MARGIN, go to lossless -- it is bit-exact, and
+        // the margin is what keeps WEBP_EFFORT from walking marginal textures across the line on
+        // its own. See WEBP_LOSSLESS_MARGIN.
         //
         // A VP8L winner is written exactly as it was encoded. Re-rating happens only on the other
         // branch, so no texture can trade a bit-exact encode for a cheaper lossy one.
-        if (lossless.length < lossy.length) {
+        if (lossless.length <= lossy.length * WEBP_LOSSLESS_MARGIN) {
             await writeFile(dest, lossless);
             console.log(`done ${dest}`);
             return;
         }
         const rated =
-            qualityFloor != null && distortionTolerance != null && distortionCeiling != null
+            qualityCeiling != null && qualityFloor != null && distortionTolerance != null && distortionCeiling != null
                 ? await selectQuality(
                       source.open,
                       source.data,
                       source.info,
-                      lossy,
-                      quality,
+                      qualityCeiling,
                       qualityFloor,
                       distortionTolerance,
                       distortionCeiling

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -7,8 +7,11 @@
 // (AssetProcessor.ProcessMaterialTextures) with a JSONL manifest of jobs. Output bytes feed the
 // content hashes embedded in CDN filenames, so sharp is pinned exact and nothing here may change
 // encoded bytes. Constraints:
-// - Every job is encoded BOTH ways -- lossy VP8 at Config.WebpQuality and fully-lossless VP8L --
-//   and the smaller output wins, with near-ties going to VP8L (see WEBP_LOSSLESS_MARGIN). This
+// - Every job is compared BOTH ways -- lossy VP8 at Config.WebpQuality against fully-lossless
+//   VP8L -- and the smaller output wins, with near-ties going to VP8L (see WEBP_LOSSLESS_MARGIN).
+//   Most jobs settle that comparison from a cheap lossless probe rather than a real VP8L encode,
+//   but only where the probe PROVES the outcome, so the codec each texture gets is the codec it
+//   would get from encoding both in full; see WEBP_LOSSLESS_PROBE_INFLATION. This
 //   replaces the param-name carve-outs that selected a codec from the material binding; see below
 //   for why picking on bytes is both smaller and safer. Note the lossy candidate is encoded at
 //   Config.WebpQuality even though a lossy winner ships at Config.WebpLossyQualityCeiling: the
@@ -38,7 +41,8 @@
 //   only the source PNG -- unlike a rule built from decompiler state, which would vary with
 //   what the workdir already had. Ties go to lossy, so the choice is total.
 //
-//   Cost: a second encode per texture. See the timing note in encode().
+//   Cost: a second encode per texture, and it is the expensive one -- VP8L runs 5.3x the lossy
+//   encode, and 86% of them are discarded. Most of that is refunded by the probe.
 // - `qualityCeiling`/`qualityFloor`/`distortionTolerance` re-rate the lossy winner AFTER min-pick
 //   has chosen the codec, and the winner is re-encoded from `qualityCeiling` down -- the
 //   comparison encode is discarded. `quality` is a single global number, but what a texture gets
@@ -260,20 +264,18 @@ function distortion(
 // makes the ladder below it reachable, and anchoring it at the comparison quality would hold every
 // texture to a budget measured on an encode none of them ship.
 //
-// Returns the QUALITY, not the buffer: every encode in here is a probe at WEBP_EFFORT_CANDIDATE
-// and none of them ship, so the caller re-encodes the answer once at WEBP_EFFORT_SHIP. Effort does
-// not move the decision -- it changes how hard the encoder searches at a given quality, not the
-// quantization the distortion is measured against -- so probing cheap and shipping expensive picks
-// the same rung.
+// Returns the rung AND the buffer encoded at it. Every rung is encoded at WEBP_EFFORT_SHIP and
+// kept, so the answer is always a buffer this function already produced and the caller writes it
+// straight out: a lossy winner pays for the encodes the search needed and not one more. That is
+// only affordable because effort 5 costs about what effort 4 does; see WEBP_EFFORT_SHIP.
 //
-// Timing: the VP8L pass is the expensive half of a job -- measured 5.3x the lossy encode's wall
-// time over a 60-texture stratified sample of the corpus (26.3s vs 5.0s). The ladder is searched
-// binary rather than walked, so this adds ~3 lossy encodes and their decodes on top of that, and
-// only on jobs where lossy already won. Binary search is valid because distortion is monotone in
-// quality: on the 42-texture sample every texture's RMSE fell at every step up the ladder.
+// Timing: three encodes and three decodes per lossy winner, one of which ships. The ladder is
+// searched binary rather than walked, which relies on distortion being monotone in quality --
+// verified on the 42-texture sample, where every texture's RMSE fell at every step up the ladder.
 //
-// If encode time ever dominates further, the cheap guard is a size floor -- the search is worth
-// ~24% of a 4 MB texture and ~24% of a 40 KB one, and only the first is worth three extra encodes.
+// A size floor is the obvious guard if this ever needs cutting again, but it is not where the time
+// is: the search costs ~24% of a texture's bytes whether it is 4 MB or 40 KB, and the encodes it
+// pays for scale with pixels, so skipping the small files skips almost no work.
 async function selectQuality(
     open: () => Sharp,
     reference: Buffer,
@@ -287,9 +289,19 @@ async function selectQuality(
     for (let step = qualityCeiling - QUALITY_LADDER_STEP; step >= floor; step -= QUALITY_LADDER_STEP) {
         ladder.push(step);
     }
-    if (ladder.length === 0) return qualityCeiling;
 
-    const probe = (quality: number) => open().webp({ quality, exact: true, effort: WEBP_EFFORT_CANDIDATE }).toBuffer();
+    // Memoized so the rung the search settles on is returned rather than re-encoded. At most three
+    // rungs are ever visited (the ceiling, then two steps of the binary search), so this holds
+    // three buffers for the life of one job.
+    const encoded = new Map<number, Buffer>();
+    const probe = async (quality: number) => {
+        const cached = encoded.get(quality);
+        if (cached !== undefined) return cached;
+        const buffer = await open().webp({ quality, exact: true, effort: WEBP_EFFORT_SHIP }).toBuffer();
+        encoded.set(quality, buffer);
+        return buffer;
+    };
+    if (ladder.length === 0) return { quality: qualityCeiling, buffer: await probe(qualityCeiling) };
     const pixels = info.width * info.height;
     const measure = async (buffer: Buffer) => {
         const { data, info: decoded } = await sharp(buffer).raw().toBuffer({ resolveWithObject: true });
@@ -315,36 +327,88 @@ async function selectQuality(
             high = middle - 1;
         }
     }
-    return best === -1 ? qualityCeiling : ladder[best]!;
+    const chosen = best === -1 ? qualityCeiling : ladder[best]!;
+    return { quality: chosen, buffer: await probe(chosen) };
 }
 
 // Quality points between rungs of the search ladder. Five is the granularity libwebp's own
 // quality scale is meaningful at; finer steps cost encodes to land on sizes a percent apart.
 const QUALITY_LADDER_STEP = 5;
 
-// libwebp's compression effort, split by what the encode is FOR. Effort is worth real bytes and
-// costs a great deal of time, so it is spent only on the encode whose bytes actually ship.
+// libwebp's compression effort, split by what the encode is FOR.
 //
-// Measured on a 14-texture sample drawn probability-proportional-to-size across the whole job
-// manifest (single-threaded seconds, effort 4 -> 6):
+// Effort is not a smooth dial on the lossy encoder. libwebp maps `method` onto a rate-distortion
+// search level and the steps are 4 = RD_OPT_BASIC, 5 = trellis quantization on the mode it picks,
+// 6 = trellis in every mode of every pass. Measured over 16 textures drawn
+// probability-proportional-to-size from the manifest, encoding the same pixels at q85:
 //
-//   lossy encode      6.3s -> 61.5s   (10x)      lossless encode  31.4s -> 189.9s  (6x)
+//   effort 4   9.99 MiB  11.4s      effort 5   9.74 MiB  12.0s      effort 6   9.60 MiB  88.3s
 //
-// against what those seconds buy, on 16 textures sampled the same way:
+// So 5 buys 2.5% of the bytes for 5% of the time, and 6 buys another 1.4% for 7.4x. 5 is the only
+// one of the three that is not a bad trade in one direction or the other, and it is what ships.
 //
-//   quantized VP8L (normals)  92.4%      lossy  94.4%      min-pick lossless candidate  99.4%
+// The min-pick candidates stay at 4, and not because 5 is expensive. A cheaper lossy candidate wins
+// min-pick more often, and the textures it would win are the masks whose lossy artifacts min-pick
+// exists to retire -- so the comparison stays pinned to the effort its margin was calibrated at
+// (see WEBP_LOSSLESS_MARGIN) and only the winner is re-rated.
 //
-// Most of a job's encodes are throwaway: the two min-pick candidates exist to pick a codec, and
-// every rung of the search ladder but one is discarded. Running those at 6 was measured at ~19
-// hours for the 19,049-job corpus, with the large majority of it spent on bytes nobody ships.
-//
-// So: candidates and ladder rungs at 4, and one final encode of the winner at 6. The quantized
-// path has no candidates -- its single encode ships -- so it runs at 6 throughout, and it is where
-// effort pays best anyway (7.6% of 2.53 GiB of normals).
-//
-// Set both to 4 if run time matters more than ~265 MiB of corpus; nothing else has to change.
+// Because effort 5 is what a lossy winner ships at AND what the search ladder is probed at, the
+// rung the search picks has already been encoded and is written as-is. The lossy side of a job
+// therefore pays for one candidate and three ladder encodes, and no fifth encode of the winner on
+// top of them. That is what makes 5 affordable where 6 was not: at effort 6 the
+// ladder cannot be probed at shipping effort, so the winner has to be encoded a fifth time, and
+// the fifth encode alone was 32% of the whole encoder's run time.
 const WEBP_EFFORT_CANDIDATE = 4;
-const WEBP_EFFORT_SHIP = 6;
+const WEBP_EFFORT_SHIP = 5;
+
+// `quality` on a LOSSLESS encode is a compression-effort dial and not a fidelity one -- the output
+// decodes bit-identically at every value, verified on sample normals at 100/90/50 -- and at effort
+// 6 it hides libwebp's single largest cliff. VP8LEncodeImage brute-forces every entropy
+// configuration when, and only when, method == 6 && quality == 100; every other pairing evaluates
+// one. Measured over 16 normals drawn probability-proportional-to-size:
+//
+//   e6 q100  54.42 MiB  452.9s      e6 q90  57.92 MiB   76.9s      e6 q50  58.16 MiB  53.9s
+//   e5 q100  57.90 MiB  128.1s      e4 q90  58.96 MiB  100.3s
+//
+// The brute force is worth 6.4% and costs 5.9x; every other combination lands within 0.5% of every
+// other, and (6, 90) is the smallest AND the fastest of them -- it beats effort 5 at quality 100 on
+// both. So the quantized path gives up the brute force: against ~2.5 GiB of normals that is ~160
+// MiB, and it was ~40% of the encoder's total run time.
+//
+// This is the quantized path only. The min-pick lossless CANDIDATE stays at quality 100 and effort
+// 4, which is not the brute-force pairing and so is not on the cliff, because its bytes both decide
+// min-pick and ship unchanged for a VP8L winner.
+const WEBP_LOSSLESS_QUALITY = 90;
+
+// The cheap lossless probe that lets most textures skip the real VP8L candidate, and the bound that
+// makes skipping safe.
+//
+// Encoding every texture losslessly is what min-pick costs, and 86% of that work is discarded:
+// measured over 620 textures sampled systematically by size, only 14.2% of min-pick jobs are VP8L
+// winners and the rest pay a full lossless encode purely to be told they are not. A lossless encode
+// at effort 1 / quality 10 costs 24% of the real candidate and was never more than
+// WEBP_LOSSLESS_PROBE_INFLATION times its size, so
+//
+//     probe > lossy * WEBP_LOSSLESS_MARGIN * WEBP_LOSSLESS_PROBE_INFLATION
+//
+// PROVES the real candidate would have lost too, and the texture takes the lossy branch without one
+// being encoded. Anything that does not clear the bound falls through to the real candidate and the
+// comparison is settled on exact bytes as before -- so no texture's codec changes, and no VP8L
+// winner's bytes change.
+//
+// 2.0 is measured, with headroom. Across those 620 textures the worst inflation was 1.967, on a
+// VP8L winner sitting at ratio 0.760 and therefore nowhere near the line, and the p99 was 1.331.
+// The figure that actually bounds the risk is how close the rule comes to firing on a texture that
+// should have won: over all 88 VP8L winners the tightest is a factor of 1.67 clear, so a probe
+// would have to come out 67% larger than anything measured before one crossed. The rule skips 61%
+// of the lossy population and takes the candidate stage to 53% of its cost.
+//
+// Effort 1 is the floor, not a tuning choice. Effort 0 sets libwebp's `low_effort` flag, which
+// drops the predictor and cross-colour transforms -- precisely what makes a mask compressible --
+// and inflation explodes to 69x on the low-entropy textures the probe most needs to recognise.
+const WEBP_LOSSLESS_PROBE_QUALITY = 10;
+const WEBP_LOSSLESS_PROBE_EFFORT = 1;
+const WEBP_LOSSLESS_PROBE_INFLATION = 2.0;
 
 // How much larger the VP8L candidate may be and still win min-pick.
 //
@@ -428,7 +492,7 @@ async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
         data[index] = table[data[index]!]!;
     }
     return sharp(data, { raw: info })
-        .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT_SHIP })
+        .webp({ lossless: true, quality: WEBP_LOSSLESS_QUALITY, exact: true, effort: 6 })
         .toBuffer();
 }
 
@@ -454,30 +518,51 @@ async function encode({
             return;
         }
         const source = await prepareSource(src, dropAlpha === true, alphaQuantizeBits ?? undefined);
-        // Both candidates exist to pick a codec, not to ship, so both are probes: encoded at
-        // `quality` rather than `qualityCeiling`, and at WEBP_EFFORT_CANDIDATE rather than the
-        // shipping effort. A cheaper lossy candidate wins min-pick more often, and the textures it
+        // The lossy candidate exists to pick a codec, not to ship: it is encoded at `quality`
+        // rather than `qualityCeiling`, and at WEBP_EFFORT_CANDIDATE rather than at the effort a
+        // winner ships at. A cheaper lossy candidate wins min-pick more often, and the textures it
         // would win are the masks whose lossy artifacts min-pick exists to retire -- so neither
         // knob is allowed to make one side of the comparison cheaper than it was.
         const lossy = await source.open().webp({ quality, exact: true, effort: WEBP_EFFORT_CANDIDATE }).toBuffer();
-        const lossless = await source
+        // The largest size a lossless candidate may come out at and still win.
+        const budget = lossy.length * WEBP_LOSSLESS_MARGIN;
+        // The lossless candidate is the expensive half of a job and is thrown away five times out
+        // of six. Encode a cheap one first: if even that clears the budget by the bound, the real
+        // one would have cleared it too, and it is never encoded at all. The bound is what keeps
+        // this from being a guess -- see WEBP_LOSSLESS_PROBE_INFLATION.
+        const losslessProbe = await source
             .open()
-            .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT_CANDIDATE })
+            .webp({
+                lossless: true,
+                quality: WEBP_LOSSLESS_PROBE_QUALITY,
+                exact: true,
+                effort: WEBP_LOSSLESS_PROBE_EFFORT
+            })
             .toBuffer();
+        const lossless =
+            losslessProbe.length > budget * WEBP_LOSSLESS_PROBE_INFLATION
+                ? undefined
+                : await source
+                      .open()
+                      .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT_CANDIDATE })
+                      .toBuffer();
         // Ties, and near-ties inside WEBP_LOSSLESS_MARGIN, go to lossless -- it is bit-exact, and
         // the margin is what keeps the alpha ladder from walking marginal textures across the line.
         // See WEBP_LOSSLESS_MARGIN.
         //
         // A VP8L winner is written exactly as it was encoded. Re-rating happens only on the other
         // branch, so no texture can trade a bit-exact encode for a cheaper lossy one.
-        if (lossless.length <= lossy.length * WEBP_LOSSLESS_MARGIN) {
-            // Not re-encoded at WEBP_EFFORT_SHIP: effort is worth only ~0.6% to a lossless encode,
-            // against ~6x its time. It is the one place the probe/ship split does not pay, so the
-            // probe is written as-is and a VP8L winner stays exactly what min-pick saw.
+        if (lossless !== undefined && lossless.length <= budget) {
+            // Written exactly as the comparison saw it. Effort is worth only ~0.6% to a lossless
+            // encode against ~6x its time, and quality 100 at effort 4 is off the brute-force
+            // cliff (see WEBP_LOSSLESS_QUALITY), so there is nothing left to re-encode for.
             await writeFile(dest, lossless);
             console.log(`done ${dest}`);
             return;
         }
+        // The search encodes its ladder at WEBP_EFFORT_SHIP and hands back the buffer for the rung
+        // it settled on, so the winner ships an encode that has already been paid for. Only a job
+        // that opted out of the search has to encode one here.
         const rated =
             qualityCeiling != null && qualityFloor != null && distortionTolerance != null && distortionCeiling != null
                 ? await selectQuality(
@@ -489,12 +574,8 @@ async function encode({
                       distortionTolerance,
                       distortionCeiling
                   )
-                : quality;
-        // The only lossy encode that ships, and the only one that pays for WEBP_EFFORT_SHIP.
-        await writeFile(
-            dest,
-            await source.open().webp({ quality: rated, exact: true, effort: WEBP_EFFORT_SHIP }).toBuffer()
-        );
+                : { buffer: await source.open().webp({ quality, exact: true, effort: WEBP_EFFORT_SHIP }).toBuffer() };
+        await writeFile(dest, rated.buffer);
         console.log(`done ${dest}`);
     } catch (error) {
         failed += 1;

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -36,6 +36,36 @@
 //   what the workdir already had. Ties go to lossy, so the choice is total.
 //
 //   Cost: a second encode per texture. See the timing note in encode().
+// - `quantizeBits` overrides min-pick for normal maps, which min-pick cannot serve. A normal's
+//   three channels are an independent vector, not a color, and lossy VP8 is YUV 4:2:0 -- so the
+//   chroma planes carry X and Y at half resolution and the downsample/upsample shifts local means.
+//   Measured on ak47_normal that biases 923 of 16,384 blocks by up to 4 levels; on
+//   ak47_autoexec_camo_normal, 6,284 of 16,384. Every biased block mirrors a slightly different
+//   patch of the environment, which renders as the square mosaic on AK-47 | AUTOEXEC's blue paint.
+//
+//   Quality does not fix it, because it is resolution loss and not quantization: at q100 the
+//   count only falls to 703 and 4,503 for 1.6x and 1.4x the bytes, with the bias unchanged at
+//   ~4 levels. Any chroma-free encode sits at 0 biased blocks -- the same encoder at the same
+//   quality, fed one channel at a time as grayscale, measures maxerr 6/7/8 against 91/54/45.
+//   Min-pick cannot reach one: VP8L is 4-6x the lossy size for a dithered normal, so lossy wins
+//   on bytes every time and ships the mosaic with it.
+//
+//   So normals skip the comparison and take a fixed path: quantize the LSB dither away, then
+//   VP8L. The dither is what makes a normal incompressible losslessly, and dropping it is what
+//   buys back the size -- 4 bits per channel lands at 1.6x lossy, against 5.1x for the
+//   near-lossless path this replaces (measured over 22 normals). Endpoints are preserved (the
+//   ladder is round(v/255*(L-1)) * 255/(L-1), so 0 and 255 map to themselves), which matters
+//   because flat normal regions sit at exactly 255 and the default normal is (127,127,255):
+//   against a plain bit-mask that halves the residual bias for free.
+//
+//   The tradeoff is a different artifact, not the absence of one. Quantization error follows the
+//   surface's own gradients rather than a 16px grid, so it reads as banding instead of mosaic,
+//   and at 4 bits a block's mean can shift by 8 levels (3.6 degrees of normal tilt). That is
+//   larger than the lossy bias it replaces; it is preferred because it is not lattice-aligned.
+//   Raising Config.WebpNormalQuantizeBits is the knob if banding shows up on a mirror surface.
+//
+//   Alpha is never quantized. A sticker's g_tNormalRoughnessSticker0 packs roughness into it,
+//   and a shader reads that as data.
 // - `exact` must stay on: 9,422 textures (2.4 GB) still carry a genuine varying alpha with
 //   fully-transparent pixels, and shader logic reads the RGB underneath. Dropping alpha where
 //   the game format has none did not retire this — it only removed the fabricated planes.
@@ -58,6 +88,7 @@ interface EncodeJob {
     dest: string;
     quality: number;
     dropAlpha?: boolean;
+    quantizeBits?: number;
 }
 
 const manifestPath = process.argv[2];
@@ -112,10 +143,34 @@ async function encodeBoth(src: string, quality: number, dropAlpha: boolean) {
     return { lossy, lossless };
 }
 
-async function encode({ src, dest, quality, dropAlpha }: EncodeJob) {
+// Quantize each colour channel onto a ladder of 2^bits evenly spaced levels, then encode VP8L.
+// Alpha is copied through untouched. bits=8 is the identity ladder, which is how a texture asks
+// for a bit-exact lossless encode without opting into min-pick.
+async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
+    const pipeline = dropAlpha ? sharp(src).removeAlpha() : sharp(src);
+    const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
+    const levels = (1 << bits) - 1;
+    const table = Buffer.alloc(256);
+    for (let value = 0; value < 256; value += 1) {
+        table[value] = Math.round((Math.round((value / 255) * levels) * 255) / levels);
+    }
+    const hasAlpha = info.channels === 4 || info.channels === 2;
+    for (let index = 0; index < data.length; index += 1) {
+        if (hasAlpha && index % info.channels === info.channels - 1) continue;
+        data[index] = table[data[index]!]!;
+    }
+    return sharp(data, { raw: info }).webp({ lossless: true, quality: 100, exact: true }).toBuffer();
+}
+
+async function encode({ src, dest, quality, dropAlpha, quantizeBits }: EncodeJob) {
     try {
         await mkdir(dirname(dest), { recursive: true });
         if (dropAlpha) await assertAlphaIsConstant(src);
+        if (quantizeBits !== undefined) {
+            await writeFile(dest, await encodeQuantized(src, quantizeBits, dropAlpha === true));
+            console.log(`done ${dest}`);
+            return;
+        }
         const { lossy, lossless } = await encodeBoth(src, quality, dropAlpha === true);
         // Ties go to lossy: it is the status quo, and preferring it keeps the winner stable for
         // any texture where the two happen to land on the same byte count.

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -147,12 +147,33 @@ async function encodeBoth(src: string, quality: number, dropAlpha: boolean) {
 // Alpha is copied through untouched. bits=8 is the identity ladder, which is how a texture asks
 // for a bit-exact lossless encode without opting into min-pick.
 async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
+    // Validated rather than trusted. A bad value here does not fail loudly, it silently ships:
+    // `levels` of 0 divides by zero, the NaN coerces to 0 on the way into a Buffer, and every
+    // texture encodes as solid black in ~200 bytes. That is what a null `quantizeBits` reaching
+    // this function once did to every non-normal in the corpus.
+    if (!Number.isInteger(bits) || bits < 1 || bits > 8) {
+        throw new Error(`quantizeBits must be an integer in 1..8, received ${bits}`);
+    }
     const pipeline = dropAlpha ? sharp(src).removeAlpha() : sharp(src);
     const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
+    // Evenly spaced rungs across the full range, so 0 and 255 map to themselves, PLUS the two
+    // neutral values. A normal map's neutral is 127/128 -- "pointing straight out" -- and on a
+    // uniform 16-rung ladder it falls exactly between rungs (127 -> 119), which tilts every flat
+    // surface in the texture by a uniform ~5 degrees rather than adding noise. Pinning it costs
+    // two extra rungs and nothing measurable in bytes.
     const levels = (1 << bits) - 1;
+    const rungs = new Set<number>([127, 128]);
+    for (let step = 0; step <= levels; step += 1) {
+        rungs.add(Math.round((step * 255) / levels));
+    }
+    const ladder = [...rungs].sort((a, b) => a - b);
     const table = Buffer.alloc(256);
     for (let value = 0; value < 256; value += 1) {
-        table[value] = Math.round((Math.round((value / 255) * levels) * 255) / levels);
+        let best = ladder[0]!;
+        for (const rung of ladder) {
+            if (Math.abs(rung - value) < Math.abs(best - value)) best = rung;
+        }
+        table[value] = best;
     }
     const hasAlpha = info.channels === 4 || info.channels === 2;
     for (let index = 0; index < data.length; index += 1) {
@@ -166,7 +187,8 @@ async function encode({ src, dest, quality, dropAlpha, quantizeBits }: EncodeJob
     try {
         await mkdir(dirname(dest), { recursive: true });
         if (dropAlpha) await assertAlphaIsConstant(src);
-        if (quantizeBits !== undefined) {
+        // Loose inequality on purpose: this must reject null as well as undefined.
+        if (quantizeBits != null) {
             await writeFile(dest, await encodeQuantized(src, quantizeBits, dropAlpha === true));
             console.log(`done ${dest}`);
             return;

--- a/scripts/item-generator-webp.ts
+++ b/scripts/item-generator-webp.ts
@@ -260,14 +260,20 @@ function distortion(
 // makes the ladder below it reachable, and anchoring it at the comparison quality would hold every
 // texture to a budget measured on an encode none of them ship.
 //
+// Returns the QUALITY, not the buffer: every encode in here is a probe at WEBP_EFFORT_CANDIDATE
+// and none of them ship, so the caller re-encodes the answer once at WEBP_EFFORT_SHIP. Effort does
+// not move the decision -- it changes how hard the encoder searches at a given quality, not the
+// quantization the distortion is measured against -- so probing cheap and shipping expensive picks
+// the same rung.
+//
 // Timing: the VP8L pass is the expensive half of a job -- measured 5.3x the lossy encode's wall
 // time over a 60-texture stratified sample of the corpus (26.3s vs 5.0s). The ladder is searched
 // binary rather than walked, so this adds ~3 lossy encodes and their decodes on top of that, and
 // only on jobs where lossy already won. Binary search is valid because distortion is monotone in
 // quality: on the 42-texture sample every texture's RMSE fell at every step up the ladder.
 //
-// If encode time ever dominates, the cheap guard is a size floor -- the search is worth ~24% of a
-// 4 MB texture and ~24% of a 40 KB one, and only the first is worth three extra encodes.
+// If encode time ever dominates further, the cheap guard is a size floor -- the search is worth
+// ~24% of a 4 MB texture and ~24% of a 40 KB one, and only the first is worth three extra encodes.
 async function selectQuality(
     open: () => Sharp,
     reference: Buffer,
@@ -277,24 +283,21 @@ async function selectQuality(
     tolerance: number,
     distortionCeiling: number
 ) {
-    const atCeiling = await open().webp({ quality: qualityCeiling, exact: true, effort: WEBP_EFFORT }).toBuffer();
     const ladder: number[] = [];
     for (let step = qualityCeiling - QUALITY_LADDER_STEP; step >= floor; step -= QUALITY_LADDER_STEP) {
         ladder.push(step);
     }
-    if (ladder.length === 0) return atCeiling;
+    if (ladder.length === 0) return qualityCeiling;
 
+    const probe = (quality: number) => open().webp({ quality, exact: true, effort: WEBP_EFFORT_CANDIDATE }).toBuffer();
     const pixels = info.width * info.height;
     const measure = async (buffer: Buffer) => {
         const { data, info: decoded } = await sharp(buffer).raw().toBuffer({ resolveWithObject: true });
         return distortion(reference, info.channels, data, decoded.channels, pixels);
     };
-    const budget = await measure(atCeiling);
-    const encoded = new Map<number, Buffer>();
+    const budget = await measure(await probe(qualityCeiling));
     const fits = async (candidate: number) => {
-        const buffer = await open().webp({ quality: candidate, exact: true, effort: WEBP_EFFORT }).toBuffer();
-        encoded.set(candidate, buffer);
-        const measured = await measure(buffer);
+        const measured = await measure(await probe(candidate));
         return measured <= budget * (1 + tolerance) && measured - budget <= distortionCeiling;
     };
 
@@ -312,43 +315,66 @@ async function selectQuality(
             high = middle - 1;
         }
     }
-    return best === -1 ? atCeiling : encoded.get(ladder[best]!)!;
+    return best === -1 ? qualityCeiling : ladder[best]!;
 }
 
 // Quality points between rungs of the search ladder. Five is the granularity libwebp's own
 // quality scale is meaningful at; finer steps cost encodes to land on sizes a percent apart.
 const QUALITY_LADDER_STEP = 5;
 
-// libwebp's compression effort, on every encode in this file. 6 buys ~1.5% of the LOSSY bytes for
-// more encoder time; it buys the VP8L candidate nothing, because sharp maps `effort` to the VP8
-// method only and a lossless encode at `quality: 100` already runs libwebp's most expensive path
-// (measured over 40 VP8L winners: every one byte-identical at effort 4 and 6).
+// libwebp's compression effort, split by what the encode is FOR. Effort is worth real bytes and
+// costs a great deal of time, so it is spent only on the encode whose bytes actually ship.
 //
-// That asymmetry is one of the two reasons WEBP_LOSSLESS_MARGIN exists. See there.
-const WEBP_EFFORT = 6;
+// Measured on a 14-texture sample drawn probability-proportional-to-size across the whole job
+// manifest (single-threaded seconds, effort 4 -> 6):
+//
+//   lossy encode      6.3s -> 61.5s   (10x)      lossless encode  31.4s -> 189.9s  (6x)
+//
+// against what those seconds buy, on 16 textures sampled the same way:
+//
+//   quantized VP8L (normals)  92.4%      lossy  94.4%      min-pick lossless candidate  99.4%
+//
+// Most of a job's encodes are throwaway: the two min-pick candidates exist to pick a codec, and
+// every rung of the search ladder but one is discarded. Running those at 6 was measured at ~19
+// hours for the 19,049-job corpus, with the large majority of it spent on bytes nobody ships.
+//
+// So: candidates and ladder rungs at 4, and one final encode of the winner at 6. The quantized
+// path has no candidates -- its single encode ships -- so it runs at 6 throughout, and it is where
+// effort pays best anyway (7.6% of 2.53 GiB of normals).
+//
+// Set both to 4 if run time matters more than ~265 MiB of corpus; nothing else has to change.
+const WEBP_EFFORT_CANDIDATE = 4;
+const WEBP_EFFORT_SHIP = 6;
 
 // How much larger the VP8L candidate may be and still win min-pick.
 //
 // Without it, every knob that makes the lossy candidate cheaper is a one-directional thumb on a
-// scale that decides FIDELITY, not just size. WEBP_EFFORT shrinks only the lossy side (~1.5%), and
-// the alpha ladder shrinks it faster than the lossless side too -- VP8L carries alpha inside its
-// own entropy coding, where a shallower ladder buys much less than it does in a separate ALPH
-// chunk. Between them they move a near-tie by 5-6%: sig_karrigan_glitter_mask goes from 0.972 to
-// 1.054 lossless/lossy purely from settings, with its pixels unchanged. Measured on 60 of the
-// non-normal VP8L winners, 5 cross to lossy on that alone -- and those winners are the masks and
-// ID maps whose lossy artifacts min-pick was built to retire, so the flips land exactly where
-// they hurt.
+// scale that decides FIDELITY, not just size. The alpha ladder is one: it shrinks a separate ALPH
+// chunk faster than it shrinks alpha carried inside VP8L's own entropy coding, so taking it from 5
+// bits to 4 moves near-ties toward lossy with the pixels unchanged. Measured on 40 of the
+// non-normal VP8L winners, that alone crosses one of them -- and those winners are the masks and
+// ID maps whose lossy artifacts min-pick was built to retire, so a flip lands exactly where it
+// hurts. Running the candidates at different efforts would be another such thumb, which is why
+// both are encoded at WEBP_EFFORT_CANDIDATE; at effort 6 on both, five of those 40 cross instead.
 //
-// 6% is measured, not guessed, and it is cheap because the two populations barely overlap. Across
-// those 60 VP8L winners the ratio distribution runs 0.015 to 1.050, with only five files above
-// 1.00; a 6% margin keeps all 60 bit-exact for 13,490 total bytes. Across 60 of today's LOSSY
-// winners the smallest ratio is 1.32 -- lossless is never within reach for a texture that genuinely
-// wants VP8 -- so the margin costs that population exactly nothing. It binds only on near-ties, and
-// near-ties belong on the bit-exact side of the line.
+// The ladder can also make a VP8L candidate BIGGER, which is the same thumb pressing harder.
+// sig_z4kr_holo_color goes 155,244 -> 179,492 bytes lossless when its alpha is snapped, while its
+// lossy candidate shrinks -- a 0.948 -> 1.169 swing in the ratio from a change to neither codec.
+// (Dropping the ladder from the lossless path is not the answer: measured over 60 VP8L winners it
+// makes them 18.2% bigger in aggregate, larger on 48 of 60, and flips 26 of 60. The holo textures
+// are the minority case, so the ladder stays and the margin absorbs them.)
+//
+// 25% is measured, not guessed, and it is nearly free because the two populations are bimodal with
+// a wide gap between them. Across 60 VP8L winners the ratio runs 0.015 to 1.179 -- 57 of them below
+// 0.99, then nothing until three holo textures at 1.169-1.179. Across 60 of today's LOSSY winners
+// the SMALLEST ratio is 1.379; lossless is never within reach for a texture that genuinely wants
+// VP8. So anything in (1.18, 1.38) separates the populations perfectly, and the margin costs the
+// lossy population exactly nothing: keeping all 60 VP8L winners bit-exact costs 76,758 bytes in
+// total, all of it on the three holo files.
 //
 // Raise it if a future knob makes lossy cheaper again and masks start flipping; the cost of raising
 // it is bounded by the margin itself, on files that are small by construction.
-const WEBP_LOSSLESS_MARGIN = 1.06;
+const WEBP_LOSSLESS_MARGIN = 1.25;
 
 // A 256-entry lookup mapping every byte to its nearest rung on a ladder of 2^bits evenly spaced
 // levels, PLUS the two neutral values. Evenly spaced across the full range means 0 and 255 map to
@@ -402,7 +428,7 @@ async function encodeQuantized(src: string, bits: number, dropAlpha: boolean) {
         data[index] = table[data[index]!]!;
     }
     return sharp(data, { raw: info })
-        .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT })
+        .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT_SHIP })
         .toBuffer();
 }
 
@@ -428,21 +454,26 @@ async function encode({
             return;
         }
         const source = await prepareSource(src, dropAlpha === true, alphaQuantizeBits ?? undefined);
-        // The comparison candidate is encoded at `quality`, NOT at `qualityCeiling`. It exists to
-        // pick a codec, not to ship: a cheaper lossy candidate wins min-pick more often, and the
-        // textures it would win are the masks whose lossy artifacts min-pick exists to retire.
-        const lossy = await source.open().webp({ quality, exact: true, effort: WEBP_EFFORT }).toBuffer();
+        // Both candidates exist to pick a codec, not to ship, so both are probes: encoded at
+        // `quality` rather than `qualityCeiling`, and at WEBP_EFFORT_CANDIDATE rather than the
+        // shipping effort. A cheaper lossy candidate wins min-pick more often, and the textures it
+        // would win are the masks whose lossy artifacts min-pick exists to retire -- so neither
+        // knob is allowed to make one side of the comparison cheaper than it was.
+        const lossy = await source.open().webp({ quality, exact: true, effort: WEBP_EFFORT_CANDIDATE }).toBuffer();
         const lossless = await source
             .open()
-            .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT })
+            .webp({ lossless: true, quality: 100, exact: true, effort: WEBP_EFFORT_CANDIDATE })
             .toBuffer();
         // Ties, and near-ties inside WEBP_LOSSLESS_MARGIN, go to lossless -- it is bit-exact, and
-        // the margin is what keeps WEBP_EFFORT from walking marginal textures across the line on
-        // its own. See WEBP_LOSSLESS_MARGIN.
+        // the margin is what keeps the alpha ladder from walking marginal textures across the line.
+        // See WEBP_LOSSLESS_MARGIN.
         //
         // A VP8L winner is written exactly as it was encoded. Re-rating happens only on the other
         // branch, so no texture can trade a bit-exact encode for a cheaper lossy one.
         if (lossless.length <= lossy.length * WEBP_LOSSLESS_MARGIN) {
+            // Not re-encoded at WEBP_EFFORT_SHIP: effort is worth only ~0.6% to a lossless encode,
+            // against ~6x its time. It is the one place the probe/ship split does not pay, so the
+            // probe is written as-is and a VP8L winner stays exactly what min-pick saw.
             await writeFile(dest, lossless);
             console.log(`done ${dest}`);
             return;
@@ -458,8 +489,12 @@ async function encode({
                       distortionTolerance,
                       distortionCeiling
                   )
-                : lossy;
-        await writeFile(dest, rated);
+                : quality;
+        // The only lossy encode that ships, and the only one that pays for WEBP_EFFORT_SHIP.
+        await writeFile(
+            dest,
+            await source.open().webp({ quality: rated, exact: true, effort: WEBP_EFFORT_SHIP }).toBuffer()
+        );
         console.log(`done ${dest}`);
     } catch (error) {
         failed += 1;

--- a/scripts/item-generator/Assets/AssetProcessor.cs
+++ b/scripts/item-generator/Assets/AssetProcessor.cs
@@ -823,6 +823,8 @@ public static partial class AssetProcessor
                 // Same gate as the alpha ladder, for the same reason: only a min-pick texture has
                 // a lossy encode to re-rate. A quantized one is already lossless, and the search
                 // has nothing to trade.
+                int? qualityCeiling =
+                    quantizeBits == null ? Config.WebpLossyQualityCeiling : null;
                 int? qualityFloor = quantizeBits == null ? Config.WebpQualityFloor : null;
                 double? distortionTolerance =
                     quantizeBits == null ? Config.WebpDistortionTolerance : null;
@@ -838,6 +840,7 @@ public static partial class AssetProcessor
                     dropAlpha,
                     quantizeBits,
                     alphaQuantizeBits,
+                    qualityCeiling,
                     qualityFloor,
                     distortionTolerance,
                     distortionCeiling

--- a/scripts/item-generator/Assets/AssetProcessor.cs
+++ b/scripts/item-generator/Assets/AssetProcessor.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using ItemGenerator.GameFiles;
 using SharpGLTF.Schema2;
@@ -739,6 +740,9 @@ public static partial class AssetProcessor
         return result;
     }
 
+    private static readonly JsonSerializerOptions EncodeJobJsonOptions =
+        new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
     private static void ProcessMaterialTextures(ItemGeneratorContext ctx)
     {
         if (Config.IsAssetReuseEnabled())
@@ -810,6 +814,8 @@ public static partial class AssetProcessor
                         normalMapTextures.Contains(normalizedResolved)
                         ? Config.WebpNormalQuantizeBits
                     : null;
+                // Null must be OMITTED, not written: the encoder selects the quantized path on
+                // the key's presence, and a null there means "quantize to null bits".
                 manifestLines.Add(JsonSerializer.Serialize(new
                 {
                     src = pngPath,
@@ -817,7 +823,7 @@ public static partial class AssetProcessor
                     quality = Config.WebpQuality,
                     dropAlpha,
                     quantizeBits
-                }));
+                }, EncodeJobJsonOptions));
                 encodeJobs.Add((resolvedVtexPath, stagedPath));
             }
             else if (File.Exists(exrPath))

--- a/scripts/item-generator/Assets/AssetProcessor.cs
+++ b/scripts/item-generator/Assets/AssetProcessor.cs
@@ -814,6 +814,12 @@ public static partial class AssetProcessor
                         normalMapTextures.Contains(normalizedResolved)
                         ? Config.WebpNormalQuantizeBits
                     : null;
+                // Only min-pick textures get their alpha plane snapped. A quantized texture is
+                // either a normal (whose alpha may pack sticker roughness) or a raw four-channel
+                // normal (whose alpha is half a hemi-octahedral pair), and both must keep it
+                // verbatim; see item-generator-webp.ts.
+                int? alphaQuantizeBits =
+                    quantizeBits == null ? Config.WebpAlphaQuantizeBits : null;
                 // Null must be OMITTED, not written: the encoder selects the quantized path on
                 // the key's presence, and a null there means "quantize to null bits".
                 manifestLines.Add(JsonSerializer.Serialize(new
@@ -822,7 +828,8 @@ public static partial class AssetProcessor
                     dest = stagedPath,
                     quality = Config.WebpQuality,
                     dropAlpha,
-                    quantizeBits
+                    quantizeBits,
+                    alphaQuantizeBits
                 }, EncodeJobJsonOptions));
                 encodeJobs.Add((resolvedVtexPath, stagedPath));
             }

--- a/scripts/item-generator/Assets/AssetProcessor.cs
+++ b/scripts/item-generator/Assets/AssetProcessor.cs
@@ -820,6 +820,14 @@ public static partial class AssetProcessor
                 // verbatim; see item-generator-webp.ts.
                 int? alphaQuantizeBits =
                     quantizeBits == null ? Config.WebpAlphaQuantizeBits : null;
+                // Same gate as the alpha ladder, for the same reason: only a min-pick texture has
+                // a lossy encode to re-rate. A quantized one is already lossless, and the search
+                // has nothing to trade.
+                int? qualityFloor = quantizeBits == null ? Config.WebpQualityFloor : null;
+                double? distortionTolerance =
+                    quantizeBits == null ? Config.WebpDistortionTolerance : null;
+                double? distortionCeiling =
+                    quantizeBits == null ? Config.WebpDistortionCeiling : null;
                 // Null must be OMITTED, not written: the encoder selects the quantized path on
                 // the key's presence, and a null there means "quantize to null bits".
                 manifestLines.Add(JsonSerializer.Serialize(new
@@ -829,7 +837,10 @@ public static partial class AssetProcessor
                     quality = Config.WebpQuality,
                     dropAlpha,
                     quantizeBits,
-                    alphaQuantizeBits
+                    alphaQuantizeBits,
+                    qualityFloor,
+                    distortionTolerance,
+                    distortionCeiling
                 }, EncodeJobJsonOptions));
                 encodeJobs.Add((resolvedVtexPath, stagedPath));
             }

--- a/scripts/item-generator/Assets/AssetProcessor.cs
+++ b/scripts/item-generator/Assets/AssetProcessor.cs
@@ -671,150 +671,6 @@ public static partial class AssetProcessor
         Log($"Extracted {FormatCount(processed.Count, "material")} and found {FormatCount(ctx.TexturesToProcess.Count, "texture reference")}.");
     }
 
-    // Texture paths bound to a *Normal* material param (g_tNormal, g_tGlitterNormal, ...) in any
-    // parsed vmat, plus a filename fallback ("_normal" in the stem) for normals that reach
-    // TexturesToProcess only through composite-material mutators or model materials. Membership
-    // selects the near-lossless WebP path (see Config.WebpNearLosslessNormals).
-    private static HashSet<string> CollectNormalMapTexturePaths(ItemGeneratorContext ctx)
-    {
-        var result = new HashSet<string>();
-        foreach (var data in ctx.MaterialDataByPath.Values)
-        {
-            if (data is not Dictionary<string, object?> vmat ||
-                !vmat.TryGetValue("m_textureParams", out var paramsObj) ||
-                paramsObj is not List<object?> textureParams)
-                continue;
-            foreach (var entry in textureParams)
-            {
-                if (entry is not Dictionary<string, object?> param ||
-                    param.GetValueOrDefault("m_name") is not string name ||
-                    !name.Contains("Normal", StringComparison.OrdinalIgnoreCase) ||
-                    param.GetValueOrDefault("m_pValue") is not string value)
-                    continue;
-                try
-                {
-                    var resolved = MaterialPaths.ResolveMaterialResourcePath(ctx, value);
-                    result.Add(MaterialPaths.NormalizeMaterialResourcePath(resolved));
-                }
-                catch { }
-            }
-        }
-        foreach (var vtexPath in ctx.TexturesToProcess)
-        {
-            if (Path.GetFileNameWithoutExtension(vtexPath)
-                .Contains("_normal", StringComparison.OrdinalIgnoreCase))
-                result.Add(vtexPath);
-        }
-        return result;
-    }
-
-    // Params a compositor reads as DATA, not color: paint zone/coverage masks (g_tMasks,
-    // g_tPaintByNumberMasks), cavity/AO (g_tAmbientOcclusion, g_tFinalAmbientOcclusion) and the
-    // glove compositor's ID maps (g_tLayerId, g_tTintId). Deliberately excludes sticker sfx
-    // masks (g_tSfxMaskSticker*) and pearlescence masks — different pipelines, unmeasured
-    // benefit.
-    //
-    // "Id" is matched case-sensitively. g_tLayerId and g_tTintId are the only texture params
-    // game-wide ending in it; the all-caps F_TINT_ID is a feature flag that also reaches this
-    // predicate through WalkLooseVariables, and only its missing texture path keeps it out.
-    private static bool IsDataSelectorParamName(string name) =>
-        name.EndsWith("Masks", StringComparison.OrdinalIgnoreCase) ||
-        name.EndsWith("Id", StringComparison.Ordinal) ||
-        name.Contains("AmbientOcclusion", StringComparison.OrdinalIgnoreCase);
-
-    private static bool HasDataSelectorFilename(string vtexPath)
-    {
-        var stem = Path.GetFileNameWithoutExtension(vtexPath);
-        return stem.Contains("_masks", StringComparison.OrdinalIgnoreCase) ||
-            stem.Contains("paintmask", StringComparison.OrdinalIgnoreCase) ||
-            stem.Contains("tintid", StringComparison.OrdinalIgnoreCase) ||
-            stem.Contains("materialid", StringComparison.OrdinalIgnoreCase) ||
-            stem.Contains("_ao_", StringComparison.OrdinalIgnoreCase) ||
-            stem.EndsWith("_ao", StringComparison.OrdinalIgnoreCase) ||
-            stem.Contains("paintao", StringComparison.OrdinalIgnoreCase) ||
-            stem.Contains("ambient_occlusion", StringComparison.OrdinalIgnoreCase) ||
-            stem.Contains("cavity", StringComparison.OrdinalIgnoreCase);
-    }
-
-    // Texture paths the customweapon and customglove compositors sample as data selectors —
-    // masks, AO and ID maps — collected from vmat texture params, composite-material loose
-    // variables (per-skin masks/AO bind through m_strName + m_strTextureRuntimeResourcePath,
-    // not m_textureParams), plus a filename fallback for the ones that reach TexturesToProcess
-    // through model materials only.
-    // Membership selects fully-lossless WebP (see Config.WebpLosslessQuality): lossy VP8 (even
-    // q95) dips flat macroblocks by 1-8/255 on a sparse 16px lattice and rings far deeper (to
-    // ±238) along mask-zone borders. The shaders amplify that: (1 - g_tMasks.x) directly blends
-    // bare-metal g_tColor into the paint, so each dipped block renders as a pixelated square on
-    // dark skins (Desert Eagle | Blaze body), and AO error shifts wear chip edges inside the
-    // 0.58..0.68 reveal band (AK-47 Asiimov). Near-binary masks also compress far BETTER
-    // lossless (pist_deagle_masks: 16 KB lossy VP8 → 1.6 KB VP8L).
-    //
-    // The glove ID maps fail the same way but harder, because a classifier reads them instead
-    // of a blend: g_tTintId decodes as ceil(r * 7) into eight buckets and g_tLayerId normalizes
-    // into per-layer weights, so a dipped macroblock crosses a bucket edge WHOLESALE and the
-    // whole block adopts a neighbouring layer's wear response. They are authored on discrete
-    // levels sitting right under those edges — glove_slick_half_back_tintid is 57% level 0 and
-    // 8% level 36, with 0 and 1 units of headroom — against a measured lossy error of up to
-    // 7/255. That map alone lands 5,362 texels (0.51%) in the wrong bucket, which renders as
-    // unworn squares on the ID maps' 16px lattice (Driver Gloves | Brocade Flowers past wear
-    // 0.30). Lossless drops it to zero, and all 37 ID maps shrink: 2177 KB VP8 → 628 KB VP8L.
-    private static HashSet<string> CollectDataSelectorTexturePaths(ItemGeneratorContext ctx)
-    {
-        var result = new HashSet<string>();
-
-        void AddResolved(string value)
-        {
-            try
-            {
-                var resolved = MaterialPaths.ResolveMaterialResourcePath(ctx, value);
-                result.Add(MaterialPaths.NormalizeMaterialResourcePath(resolved));
-            }
-            catch { }
-        }
-
-        foreach (var data in ctx.MaterialDataByPath.Values)
-        {
-            if (data is not Dictionary<string, object?> vmat ||
-                !vmat.TryGetValue("m_textureParams", out var paramsObj) ||
-                paramsObj is not List<object?> textureParams)
-                continue;
-            foreach (var entry in textureParams)
-            {
-                if (entry is not Dictionary<string, object?> param ||
-                    param.GetValueOrDefault("m_name") is not string name ||
-                    !IsDataSelectorParamName(name) ||
-                    param.GetValueOrDefault("m_pValue") is not string value)
-                    continue;
-                AddResolved(value);
-            }
-        }
-
-        void WalkLooseVariables(object? node)
-        {
-            if (node is Dictionary<string, object?> dict)
-            {
-                if (dict.GetValueOrDefault("m_strName") is string name &&
-                    IsDataSelectorParamName(name) &&
-                    dict.GetValueOrDefault("m_strTextureRuntimeResourcePath") is string path &&
-                    path.Length > 0)
-                    AddResolved(path);
-                foreach (var value in dict.Values) WalkLooseVariables(value);
-            }
-            else if (node is List<object?> list)
-            {
-                foreach (var value in list) WalkLooseVariables(value);
-            }
-        }
-        foreach (var data in ctx.CompositeMaterialDataByPath.Values) WalkLooseVariables(data);
-
-        foreach (var vtexPath in ctx.TexturesToProcess)
-        {
-            if (HasDataSelectorFilename(vtexPath))
-                result.Add(vtexPath);
-        }
-        return result;
-    }
-
     private static void ProcessMaterialTextures(ItemGeneratorContext ctx)
     {
         if (Config.IsAssetReuseEnabled())
@@ -828,14 +684,11 @@ public static partial class AssetProcessor
         if (pending.Count == 0) return;
 
         Log($"Processing {FormatCount(pending.Count, "material texture")}...");
-        var normalMapTextures = CollectNormalMapTexturePaths(ctx);
-        var dataSelectorTextures = CollectDataSelectorTexturePaths(ctx);
-
         var compiledPaths = pending.Select(MaterialPaths.ToCompiledMaterialResourcePath).ToList();
         // Keyed on the RESOLVED vpk path, because that is what the encode loop below compares
         // against. ResolveMaterialResourcePath falls back to matching the filename anywhere in
         // the index, so the resolved path is not always the string we started from, and keying
-        // on the unresolved one would silently drop the lossless flag for anything relocated.
+        // on the unresolved one would silently drop the alpha flag for anything relocated.
         var resolvedCompiledPaths = new List<string>(pending.Count);
         foreach (var vtexPath in pending)
         {
@@ -846,8 +699,7 @@ public static partial class AssetProcessor
             }
             catch { }
         }
-        var (rawFourChannelNormals, syntheticAlphaTextures) =
-            TextureCodecPolicy.Collect(ctx, resolvedCompiledPaths);
+        var syntheticAlphaTextures = TextureCodecPolicy.Collect(ctx, resolvedCompiledPaths);
         ResourceDecompiler.DecompileAssets(ctx, compiledPaths);
 
         var stagingDir = Path.Combine(Config.ItemGeneratorBuildDir, "textures");
@@ -871,17 +723,6 @@ public static partial class AssetProcessor
             if (File.Exists(pngPath))
             {
                 var stagedPath = Path.Combine(stagingDir, $"{encodeJobs.Count}.webp");
-                var normalizedResolved = MaterialPaths.NormalizeMaterialResourcePath(resolvedVtexPath);
-                // Lossless (data selectors) wins over near-lossless (normals) when both match.
-                // Raw four-channel normals are data too: their channels are a packed
-                // hemi-octahedral pair and an anisotropic roughness pair, decoded non-linearly
-                // downstream, so near-lossless preprocessing would perturb the decoded normal
-                // rather than the stored value. See TextureCodecPolicy.
-                var lossless = dataSelectorTextures.Contains(vtexPath) ||
-                    dataSelectorTextures.Contains(normalizedResolved) ||
-                    rawFourChannelNormals.Contains(vpkPath);
-                var nearLossless = !lossless && (normalMapTextures.Contains(vtexPath) ||
-                    normalMapTextures.Contains(normalizedResolved));
                 // The game's format for this texture has no alpha channel, so whatever VRF put
                 // in the exported one is its decoder's invention. See TextureCodecPolicy.
                 var dropAlpha = syntheticAlphaTextures.Contains(vpkPath);
@@ -889,13 +730,7 @@ public static partial class AssetProcessor
                 {
                     src = pngPath,
                     dest = stagedPath,
-                    // For near-lossless encodes, quality is libwebp's near-lossless level; for
-                    // lossless it's VP8L's compression effort (not a fidelity knob).
-                    quality = lossless ? Config.WebpLosslessQuality
-                        : nearLossless ? Config.WebpNearLosslessNormals
-                        : Config.WebpQuality,
-                    nearLossless,
-                    lossless,
+                    quality = Config.WebpQuality,
                     dropAlpha
                 }));
                 encodeJobs.Add((resolvedVtexPath, stagedPath));

--- a/scripts/item-generator/Assets/AssetProcessor.cs
+++ b/scripts/item-generator/Assets/AssetProcessor.cs
@@ -671,6 +671,74 @@ public static partial class AssetProcessor
         Log($"Extracted {FormatCount(processed.Count, "material")} and found {FormatCount(ctx.TexturesToProcess.Count, "texture reference")}.");
     }
 
+    // Texture paths bound to a *Normal* material param, collected from the material graph only:
+    // vmat m_textureParams (g_tNormal, g_tGlitterNormal, g_tDamageNormal1, ...) plus the
+    // composite-material loose variables that per-skin paint normals bind through
+    // (m_strName + m_strTextureRuntimeResourcePath). A declared m_nTextureType of
+    // INPUT_TEXTURE_TYPE_NORMALMAP counts on its own, since it states the role outright.
+    // Membership selects the quantized-lossless path (see Config.WebpNormalQuantizeBits).
+    //
+    // Deliberately has NO filename fallback. Filenames misdescribe the corpus in both
+    // directions: 198 textures bound as g_tNormalRoughnessSticker0 by csgo_weapon_sticker.vfx
+    // are named *_selfillum_mask (their RGB is a flat 127/127/255 normal with roughness packed
+    // into alpha, so the binding is right and the name is wrong), and the only path a "_normal"
+    // stem finds that the graph does not is a 1x1 36-byte default no material references.
+    // Matching the binding gets all 198 and costs nothing.
+    private static HashSet<string> CollectNormalMapTexturePaths(ItemGeneratorContext ctx)
+    {
+        var result = new HashSet<string>();
+
+        void AddResolved(string value)
+        {
+            try
+            {
+                var resolved = MaterialPaths.ResolveMaterialResourcePath(ctx, value);
+                result.Add(MaterialPaths.NormalizeMaterialResourcePath(resolved));
+            }
+            catch { }
+        }
+
+        static bool IsNormalParamName(string name) =>
+            name.Contains("Normal", StringComparison.OrdinalIgnoreCase);
+
+        foreach (var data in ctx.MaterialDataByPath.Values)
+        {
+            if (data is not Dictionary<string, object?> vmat ||
+                !vmat.TryGetValue("m_textureParams", out var paramsObj) ||
+                paramsObj is not List<object?> textureParams)
+                continue;
+            foreach (var entry in textureParams)
+            {
+                if (entry is not Dictionary<string, object?> param ||
+                    param.GetValueOrDefault("m_name") is not string name ||
+                    !IsNormalParamName(name) ||
+                    param.GetValueOrDefault("m_pValue") is not string value)
+                    continue;
+                AddResolved(value);
+            }
+        }
+
+        void WalkLooseVariables(object? node)
+        {
+            if (node is Dictionary<string, object?> dict)
+            {
+                if (dict.GetValueOrDefault("m_strTextureRuntimeResourcePath") is string path &&
+                    path.Length > 0 &&
+                    ((dict.GetValueOrDefault("m_strName") is string name && IsNormalParamName(name)) ||
+                        dict.GetValueOrDefault("m_nTextureType") is "INPUT_TEXTURE_TYPE_NORMALMAP"))
+                    AddResolved(path);
+                foreach (var value in dict.Values) WalkLooseVariables(value);
+            }
+            else if (node is List<object?> list)
+            {
+                foreach (var value in list) WalkLooseVariables(value);
+            }
+        }
+        foreach (var data in ctx.CompositeMaterialDataByPath.Values) WalkLooseVariables(data);
+
+        return result;
+    }
+
     private static void ProcessMaterialTextures(ItemGeneratorContext ctx)
     {
         if (Config.IsAssetReuseEnabled())
@@ -699,7 +767,9 @@ public static partial class AssetProcessor
             }
             catch { }
         }
-        var syntheticAlphaTextures = TextureCodecPolicy.Collect(ctx, resolvedCompiledPaths);
+        var (rawFourChannelNormals, syntheticAlphaTextures) =
+            TextureCodecPolicy.Collect(ctx, resolvedCompiledPaths);
+        var normalMapTextures = CollectNormalMapTexturePaths(ctx);
         ResourceDecompiler.DecompileAssets(ctx, compiledPaths);
 
         var stagingDir = Path.Combine(Config.ItemGeneratorBuildDir, "textures");
@@ -726,12 +796,27 @@ public static partial class AssetProcessor
                 // The game's format for this texture has no alpha channel, so whatever VRF put
                 // in the exported one is its decoder's invention. See TextureCodecPolicy.
                 var dropAlpha = syntheticAlphaTextures.Contains(vpkPath);
+                var normalizedResolved =
+                    MaterialPaths.NormalizeMaterialResourcePath(resolvedVtexPath);
+                // A raw four-channel normal is packed data, not a vector: its channels are a
+                // hemi-octahedral pair and an anisotropic roughness pair, decoded non-linearly
+                // downstream, so quantizing the stored value perturbs the decoded normal by an
+                // unbounded amount. Those take the identity ladder -- bit-exact lossless, and
+                // still out of min-pick, whose lossy candidate would wreck them. See
+                // TextureCodecPolicy.
+                int? quantizeBits =
+                    rawFourChannelNormals.Contains(vpkPath) ? 8
+                    : normalMapTextures.Contains(vtexPath) ||
+                        normalMapTextures.Contains(normalizedResolved)
+                        ? Config.WebpNormalQuantizeBits
+                    : null;
                 manifestLines.Add(JsonSerializer.Serialize(new
                 {
                     src = pngPath,
                     dest = stagedPath,
                     quality = Config.WebpQuality,
-                    dropAlpha
+                    dropAlpha,
+                    quantizeBits
                 }));
                 encodeJobs.Add((resolvedVtexPath, stagedPath));
             }

--- a/scripts/item-generator/Assets/AssetProcessor.cs
+++ b/scripts/item-generator/Assets/AssetProcessor.cs
@@ -846,7 +846,8 @@ public static partial class AssetProcessor
             }
             catch { }
         }
-        var rawFourChannelNormals = TextureCodecPolicy.Collect(ctx, resolvedCompiledPaths);
+        var (rawFourChannelNormals, syntheticAlphaTextures) =
+            TextureCodecPolicy.Collect(ctx, resolvedCompiledPaths);
         ResourceDecompiler.DecompileAssets(ctx, compiledPaths);
 
         var stagingDir = Path.Combine(Config.ItemGeneratorBuildDir, "textures");
@@ -881,6 +882,9 @@ public static partial class AssetProcessor
                     rawFourChannelNormals.Contains(vpkPath);
                 var nearLossless = !lossless && (normalMapTextures.Contains(vtexPath) ||
                     normalMapTextures.Contains(normalizedResolved));
+                // The game's format for this texture has no alpha channel, so whatever VRF put
+                // in the exported one is its decoder's invention. See TextureCodecPolicy.
+                var dropAlpha = syntheticAlphaTextures.Contains(vpkPath);
                 manifestLines.Add(JsonSerializer.Serialize(new
                 {
                     src = pngPath,
@@ -891,7 +895,8 @@ public static partial class AssetProcessor
                         : nearLossless ? Config.WebpNearLosslessNormals
                         : Config.WebpQuality,
                     nearLossless,
-                    lossless
+                    lossless,
+                    dropAlpha
                 }));
                 encodeJobs.Add((resolvedVtexPath, stagedPath));
             }

--- a/scripts/item-generator/Config.cs
+++ b/scripts/item-generator/Config.cs
@@ -51,20 +51,25 @@ public static partial class Config
         "community_mix01", "community02", "danger_zone",
         "standard", "stickers2", "tournament_assets"
     ];
+    // Every texture takes the same lossy VP8 encode. The old carve-outs -- fully-lossless VP8L
+    // for data selectors (masks, AO, glove ID maps) and near-lossless for normal maps -- were
+    // not an optimization at all on this corpus: measured over a 60-texture stratified sample,
+    // near-lossless level 60 is byte-for-byte the lossless size, and dropping it to level 20
+    // buys 2.8% on normals and 0.0% on data selectors. They were carrying 6,084 of the 11,038 MB
+    // we ship (55%) essentially uncompressed. At q95 the same files land 73% (normals) and 65%
+    // (data selectors) smaller, taking the corpus to ~6.7 GB.
+    //
+    // What that costs is real and worth knowing before lowering this further. VP8 is YUV 4:2:0,
+    // so any texture whose channels are independent data rather than a color loses the most:
+    // measured max per-channel error is 177 on normal maps, 223 on packed ORM (occlusion,
+    // roughness, metalness in r/g/b) and 255 along the hard borders of paint-by-number masks,
+    // versus 8-11 on plain grayscale AO. That is the error budget the previous carve-outs
+    // existed to avoid -- see git history for the artifacts it produced in cs2-3d-viewer
+    // (pixelated squares on Desert Eagle | Blaze, mis-bucketed wear on Driver Gloves | Brocade
+    // Flowers, a faint mosaic on metallic normals).
+    //
+    // Also used for the SkiaSharp-encoded item images in Catalog/Assets.cs.
     public const int WebpQuality = 95;
-    // Lossy WebP (even at q95) quantizes away the ±1 dither in normal maps, collapsing them
-    // into flat DCT plateaus; on metallic skins every plateau mirrors a slightly different
-    // patch of the environment and the surface reads as a faint square mosaic in cs2-3d-viewer.
-    // Normal maps therefore use WebP near-lossless: still the lossless coder (no block
-    // structure), with bounded per-pixel adjustment. Level 60 keeps the max per-channel
-    // error at ±2 (vs ±91 measured at lossy q95 on ak47_normal) for ~2/3 the lossless size.
-    // Passed to scripts/item-generator-webp.ts as the near-lossless level (sharp reuses `quality`).
-    public const int WebpNearLosslessNormals = 60;
-    // Data-selector composite inputs (paint masks, AO/cavity, glove ID maps — see
-    // AssetProcessor.CollectDataSelectorTexturePaths) are sampled as data, not color, so
-    // they encode fully lossless (VP8L). In lossless mode libwebp's quality knob trades
-    // encode time for size with zero fidelity impact; 100 = smallest files.
-    public const int WebpLosslessQuality = 100;
     public const int CdnUploadConcurrency = 40;
     public static readonly int ExternalConcurrency = Math.Max(2, Environment.ProcessorCount);
 

--- a/scripts/item-generator/Config.cs
+++ b/scripts/item-generator/Config.cs
@@ -77,17 +77,22 @@ public static partial class Config
     // how they are identified).
     //
     // This is the size/fidelity dial for ~5,400 textures, 1.86 GB of the corpus at the lossy
-    // encode they must stop using. Measured over 22 normals, against that baseline:
+    // encode they must stop using. Cost against that baseline, by bit depth:
     //
     //   8 bits (bit-exact)     x5.97     7 bits (max err 1)   x3.88
     //   6 bits (max err 2)     x2.85     5 bits (max err 4)   x2.11
-    //   4 bits (max err 8)     x1.62
+    //   4 bits (max err 8)     x2.14
+    //
+    // Ratios come from samples of ~20 normals and vary by several points between samples, so
+    // read them as the shape of the curve rather than exact figures; 4 bits is the one measured
+    // through the shipped encoder, and puts corpus normals near 3.98 GB.
     //
     // For reference the near-lossless path this replaces was x5.08 at max err 2, so 6 bits is
     // strictly better than what shipped before this branch. 4 bits is the deliberate choice to
     // spend fidelity on size: max err 8 is 3.6 degrees of normal tilt, and quantization bias
     // follows the surface gradient, so the failure mode if it is too aggressive is banding on a
-    // smooth mirror-like surface. Raise this if that shows up.
+    // smooth mirror-like surface. Raise this if that shows up. Note the encoder pins 127/128
+    // onto the ladder whatever this is set to, so a flat surface never picks up a uniform tilt.
     public const int WebpNormalQuantizeBits = 4;
     public const int CdnUploadConcurrency = 40;
     public static readonly int ExternalConcurrency = Math.Max(2, Environment.ProcessorCount);

--- a/scripts/item-generator/Config.cs
+++ b/scripts/item-generator/Config.cs
@@ -116,6 +116,38 @@ public static partial class Config
     // the one place alpha is a genuine gradient -- a sticker's transparency ramp, where the
     // failure mode if this is too aggressive is banding on a soft edge. Raise it if that shows up.
     public const int WebpAlphaQuantizeBits = 5;
+    // Floor and budget for the per-texture quality search that re-rates a lossy min-pick winner.
+    // `WebpQuality` sets what a texture may spend; these decide whether spending it buys anything
+    // on THAT texture. See item-generator-webp.ts for the mechanism and for why the search runs
+    // after min-pick rather than before it.
+    //
+    // This is the size/fidelity dial for the ~11,900 textures that ship a lossy encode, 3.48 GB of
+    // the 6.10 GB corpus. Measured over a 42-texture sample stratified by size rank, against
+    // their q95 bytes:
+    //
+    //   tolerance 5%    88.7%  (26 of 42 stay at full quality)
+    //   tolerance 10%   75.9%  (15 of 42)
+    //   tolerance 15%   70.5%  (13 of 42)
+    //   tolerance 20%   68.8%  (12 of 42)
+    //
+    // Confirmed on an unbiased 112-texture random sample at 10%: 22.7% of the lossy bytes, with
+    // 25 of 112 left at full quality, and no texture over budget (worst distortion ratio 1.100).
+    //
+    // 10% is the deliberate pick: it is where the curve turns over, and the textures it moves are
+    // the ones whose q95 error is dominated by 4:2:0 chroma subsampling -- which quality does not
+    // control, so the quality points were buying them a rounding difference on an error they
+    // already carry. Past 10% the rule starts taking bits from clean colour textures, where they
+    // buy real fidelity, for a few more points of size.
+    //
+    // The tolerance is RELATIVE, so a texture that q95 already encodes cleanly is held to a tight
+    // budget and a distorted one to a loose one. `WebpDistortionCeiling` bounds the loose end in
+    // absolute levels, so an already-damaged texture cannot be damaged without limit; at 10% it
+    // binds only above an RMSE of 20, which in this corpus is the large paint-by-number masks.
+    // Both are what to raise if a lossy texture looks soft, and `WebpQualityFloor` is what to
+    // raise if one looks blocky.
+    public const int WebpQualityFloor = 70;
+    public const double WebpDistortionTolerance = 0.10;
+    public const double WebpDistortionCeiling = 2.0;
     public const int CdnUploadConcurrency = 40;
     public static readonly int ExternalConcurrency = Math.Max(2, Environment.ProcessorCount);
 

--- a/scripts/item-generator/Config.cs
+++ b/scripts/item-generator/Config.cs
@@ -51,24 +51,24 @@ public static partial class Config
         "community_mix01", "community02", "danger_zone",
         "standard", "stickers2", "tournament_assets"
     ];
-    // Every texture takes the same lossy VP8 encode. The old carve-outs -- fully-lossless VP8L
-    // for data selectors (masks, AO, glove ID maps) and near-lossless for normal maps -- were
-    // not an optimization at all on this corpus: measured over a 60-texture stratified sample,
-    // near-lossless level 60 is byte-for-byte the lossless size, and dropping it to level 20
-    // buys 2.8% on normals and 0.0% on data selectors. They were carrying 6,084 of the 11,038 MB
-    // we ship (55%) essentially uncompressed. At q95 the same files land 73% (normals) and 65%
-    // (data selectors) smaller, taking the corpus to ~6.7 GB.
+    // The lossy Q for the VP8 half of the encoder's two candidates. Every texture is encoded both
+    // this way and fully-lossless VP8L, and the smaller output ships; see item-generator-webp.ts.
     //
-    // What that costs is real and worth knowing before lowering this further. VP8 is YUV 4:2:0,
-    // so any texture whose channels are independent data rather than a color loses the most:
-    // measured max per-channel error is 177 on normal maps, 223 on packed ORM (occlusion,
-    // roughness, metalness in r/g/b) and 255 along the hard borders of paint-by-number masks,
-    // versus 8-11 on plain grayscale AO. That is the error budget the previous carve-outs
-    // existed to avoid -- see git history for the artifacts it produced in cs2-3d-viewer
-    // (pixelated squares on Desert Eagle | Blaze, mis-bucketed wear on Driver Gloves | Brocade
-    // Flowers, a faint mosaic on metallic normals).
+    // Lowering this is not the free win it looks like. VP8 is YUV 4:2:0, so any texture whose
+    // channels are independent data rather than a color loses the most: measured max per-channel
+    // error at q95 is 177 on normal maps, 223 on packed ORM (occlusion, roughness, metalness in
+    // r/g/b) and 255 along the hard borders of paint-by-number masks, versus 8-11 on plain
+    // grayscale AO. Dropping Q widens that budget on exactly the textures a shader reads as data.
     //
-    // Also used for the SkiaSharp-encoded item images in Catalog/Assets.cs.
+    // Min-pick already covers the worst of it: the textures that break most visibly under lossy
+    // are low-entropy, so VP8L both wins on bytes and is bit-exact for them. That is what fixed
+    // the pixelated squares on Desert Eagle | Blaze -- its g_tMasks is 27.9 KB lossy vs 10.3 KB
+    // lossless. It is NOT a general safety net: a high-entropy texture that a shader still reads
+    // as data (the large paint-by-number masks, most normals) keeps the lossy encode because
+    // VP8L is bigger for it, and keeps this error budget with it.
+    //
+    // Also used for the SkiaSharp-encoded item images in Catalog/Assets.cs, which are single-path
+    // lossy and do not go through min-pick.
     public const int WebpQuality = 95;
     public const int CdnUploadConcurrency = 40;
     public static readonly int ExternalConcurrency = Math.Max(2, Environment.ProcessorCount);

--- a/scripts/item-generator/Config.cs
+++ b/scripts/item-generator/Config.cs
@@ -94,6 +94,28 @@ public static partial class Config
     // smooth mirror-like surface. Raise this if that shows up. Note the encoder pins 127/128
     // onto the ladder whatever this is set to, so a flat surface never picks up a uniform tilt.
     public const int WebpNormalQuantizeBits = 4;
+    // Bits per pixel kept in the ALPHA plane of every texture that goes through min-pick. RGB is
+    // untouched; this is only the separate ALPH chunk, which WebP always compresses losslessly and
+    // which `WebpQuality` therefore cannot reach. See item-generator-webp.ts for why quantizing is
+    // preferred over libwebp's own alphaQuality.
+    //
+    // This is the size/fidelity dial for 11,263 textures, 3.52 GiB of the 6.95 GiB corpus, of
+    // which 1.17 GiB is the alpha planes themselves. Cost against that baseline, measured on a
+    // 60-texture sample stratified by size rank:
+    //
+    //   6 bits (max err 2)   84.1%     5 bits (max err 4)   75.4%     4 bits (max err 8)   69.6%
+    //
+    // The saving is far larger than that average on the files that actually hurt, because it
+    // scales with how dithered the plane is: at 5 bits, ak47_autoexec_camo albedo 4.21 -> 1.59 MB,
+    // p2000_deep_red 6.76 -> 3.75 MB, mp5_statics_blue 6.81 -> 3.01 MB.
+    //
+    // 5 bits is the deliberate pick. Alpha in this corpus is a mask read through smoothstep, not a
+    // colour, so max err 4 (1.6% of range) moves a wear threshold by far less than the wear slider
+    // itself does, and unlike the normals ladder there is no unbounded decode downstream to
+    // amplify it. Going to 4 buys another 6 points for double the error, which is not worth it on
+    // the one place alpha is a genuine gradient -- a sticker's transparency ramp, where the
+    // failure mode if this is too aggressive is banding on a soft edge. Raise it if that shows up.
+    public const int WebpAlphaQuantizeBits = 5;
     public const int CdnUploadConcurrency = 40;
     public static readonly int ExternalConcurrency = Math.Max(2, Environment.ProcessorCount);
 

--- a/scripts/item-generator/Config.cs
+++ b/scripts/item-generator/Config.cs
@@ -70,7 +70,30 @@ public static partial class Config
     //
     // Also used for the SkiaSharp-encoded item images in Catalog/Assets.cs, which are single-path
     // lossy and do not go through min-pick.
+    // NOTE this is the quality the min-pick COMPARISON candidate is encoded at, and it is
+    // deliberately not the quality a lossy winner ships at -- see WebpLossyQualityCeiling. Pinning
+    // the comparison here keeps the codec choice identical to what it was before the ceiling
+    // existed, so no texture can trade a bit-exact VP8L encode for a cheaper lossy one.
     public const int WebpQuality = 95;
+    // The highest quality a texture that ALREADY WON min-pick may ship at. `WebpQuality` decides
+    // which codec a texture gets; this decides what the lossy winners cost, and the per-texture
+    // search descends from here toward `WebpQualityFloor`.
+    //
+    // The two are separate because they answer different questions, and answering both with one
+    // number is what made this expensive. Lowering `WebpQuality` to 85 outright would also shrink
+    // the comparison candidate, and the lossy candidate winning more often is precisely the
+    // outcome min-pick exists to prevent: measured on a 40-texture sample of the non-normal VP8L
+    // winners (the masks and ID maps), 14 of 40 flip to lossy at a comparison quality of 85. Those
+    // are the textures whose lossy encode brings back the 16px mosaic. Comparing at 95 and
+    // shipping at 85 takes the size and leaves the codec decision untouched.
+    //
+    // 85 is the deliberate pick. It is the point where the search's own reference moves: the
+    // budget is measured on THIS texture at the ceiling, so a lower ceiling both caps the top rung
+    // and loosens the relative tolerance below it. Measured over a 24-texture sample drawn
+    // probability-proportional-to-size from the lossy textures that carry an alpha plane, a
+    // ceiling of 85 lands the corpus at 46.3% of its q95 bytes, with most textures settling at 80
+    // or 85 rather than at the ceiling itself. Raise it if a lossy texture looks soft.
+    public const int WebpLossyQualityCeiling = 85;
     // Bits per colour channel kept for normal maps, which are quantized onto a 2^n level ladder
     // and then encoded lossless instead of going through min-pick (see item-generator-webp.ts for
     // why no lossy setting can serve them, and AssetProcessor.CollectNormalMapTexturePaths for
@@ -109,13 +132,22 @@ public static partial class Config
     // scales with how dithered the plane is: at 5 bits, ak47_autoexec_camo albedo 4.21 -> 1.59 MB,
     // p2000_deep_red 6.76 -> 3.75 MB, mp5_statics_blue 6.81 -> 3.01 MB.
     //
-    // 5 bits is the deliberate pick. Alpha in this corpus is a mask read through smoothstep, not a
-    // colour, so max err 4 (1.6% of range) moves a wear threshold by far less than the wear slider
-    // itself does, and unlike the normals ladder there is no unbounded decode downstream to
-    // amplify it. Going to 4 buys another 6 points for double the error, which is not worth it on
-    // the one place alpha is a genuine gradient -- a sticker's transparency ramp, where the
-    // failure mode if this is too aggressive is banding on a soft edge. Raise it if that shows up.
-    public const int WebpAlphaQuantizeBits = 5;
+    // Alpha in this corpus is a mask read through smoothstep, not a colour, so the error moves a
+    // wear threshold by far less than the wear slider itself does, and unlike the normals ladder
+    // there is no unbounded decode downstream to amplify it. The one place alpha is a genuine
+    // gradient is a sticker's transparency ramp.
+    //
+    // Note the saving is bounded by how DITHERED the plane is, not by how large it is. A plane
+    // that is genuine per-pixel noise rather than a dithered plateau barely responds at any depth:
+    // gun_grunge_psd's alpha costs 1.51 MiB at 5 bits, 1.28 at 4, and still 0.67 at ONE bit. No
+    // setting of this makes such a texture cheap; only fewer pixels would.
+    // 4 is the pick as of the ceiling change. 5 was chosen when the alpha ladder was the only
+    // lever on these files; now that the RGB side moves too, the extra bit is a bigger share of
+    // what is left. It costs max err 8 instead of 4 (3.1% of range) and buys ~7% of the bytes of
+    // every texture that carries an alpha plane, measured over the same 24-texture sample. The
+    // failure mode is unchanged -- banding on a sticker's transparency ramp -- so go back to 5 if
+    // that shows up.
+    public const int WebpAlphaQuantizeBits = 4;
     // Floor and budget for the per-texture quality search that re-rates a lossy min-pick winner.
     // `WebpQuality` sets what a texture may spend; these decide whether spending it buys anything
     // on THAT texture. See item-generator-webp.ts for the mechanism and for why the search runs

--- a/scripts/item-generator/Config.cs
+++ b/scripts/item-generator/Config.cs
@@ -64,12 +64,31 @@ public static partial class Config
     // are low-entropy, so VP8L both wins on bytes and is bit-exact for them. That is what fixed
     // the pixelated squares on Desert Eagle | Blaze -- its g_tMasks is 27.9 KB lossy vs 10.3 KB
     // lossless. It is NOT a general safety net: a high-entropy texture that a shader still reads
-    // as data (the large paint-by-number masks, most normals) keeps the lossy encode because
-    // VP8L is bigger for it, and keeps this error budget with it.
+    // as data (the large paint-by-number masks) keeps the lossy encode because VP8L is bigger
+    // for it, and keeps this error budget with it. Normal maps are the case where that went
+    // visibly wrong, and they are routed around min-pick entirely; see WebpNormalQuantizeBits.
     //
     // Also used for the SkiaSharp-encoded item images in Catalog/Assets.cs, which are single-path
     // lossy and do not go through min-pick.
     public const int WebpQuality = 95;
+    // Bits per colour channel kept for normal maps, which are quantized onto a 2^n level ladder
+    // and then encoded lossless instead of going through min-pick (see item-generator-webp.ts for
+    // why no lossy setting can serve them, and AssetProcessor.CollectNormalMapTexturePaths for
+    // how they are identified).
+    //
+    // This is the size/fidelity dial for ~5,400 textures, 1.86 GB of the corpus at the lossy
+    // encode they must stop using. Measured over 22 normals, against that baseline:
+    //
+    //   8 bits (bit-exact)     x5.97     7 bits (max err 1)   x3.88
+    //   6 bits (max err 2)     x2.85     5 bits (max err 4)   x2.11
+    //   4 bits (max err 8)     x1.62
+    //
+    // For reference the near-lossless path this replaces was x5.08 at max err 2, so 6 bits is
+    // strictly better than what shipped before this branch. 4 bits is the deliberate choice to
+    // spend fidelity on size: max err 8 is 3.6 degrees of normal tilt, and quantization bias
+    // follows the surface gradient, so the failure mode if it is too aggressive is banding on a
+    // smooth mirror-like surface. Raise this if that shows up.
+    public const int WebpNormalQuantizeBits = 4;
     public const int CdnUploadConcurrency = 40;
     public static readonly int ExternalConcurrency = Math.Max(2, Environment.ProcessorCount);
 

--- a/scripts/item-generator/GameFiles/TextureCodecPolicy.cs
+++ b/scripts/item-generator/GameFiles/TextureCodecPolicy.cs
@@ -15,7 +15,9 @@ namespace ItemGenerator.GameFiles;
 /// Two independent questions, both answered from the compiled header alone:
 /// <see cref="IsRawFourChannelNormal"/> asks whether VRF's HemiOct decode would destroy a
 /// channel the game stores, and <see cref="HasSyntheticAlpha"/> asks whether VRF's decode
-/// invents one the game does not.
+/// invents one the game does not. The first is asked per resource as it is decompiled
+/// (<see cref="ResourceDecompiler"/>); the second in a batch up front (<see cref="Collect"/>),
+/// because the encoder needs the answer for every texture before any of them is encoded.
 ///
 /// The first case: the textures whose four channels must be exported verbatim instead of
 /// through ValveResourceFormat's HemiOct decode.
@@ -106,16 +108,8 @@ public static class TextureCodecPolicy
     }
 
     /// <summary>
-    /// The subsets of <paramref name="vpkPaths"/> that <see cref="IsRawFourChannelNormal"/> and
-    /// <see cref="HasSyntheticAlpha"/> hold for. Disjoint by construction: the former requires
-    /// BC7, which <see cref="AlphaFreeFormats"/> excludes.
-    /// </summary>
-    public readonly record struct Sets(
-        HashSet<string> RawFourChannelNormals,
-        HashSet<string> SyntheticAlpha);
-
-    /// <summary>
-    /// Classifies <paramref name="vpkPaths"/>, as normalized VPK paths.
+    /// The subset of <paramref name="vpkPaths"/>, as normalized VPK paths, that
+    /// <see cref="HasSyntheticAlpha"/> holds for.
     ///
     /// Deliberately re-reads the vtex_c headers rather than recording what
     /// <see cref="ResourceDecompiler"/> saw: decompilation skips textures already present in the
@@ -126,16 +120,16 @@ public static class TextureCodecPolicy
     /// Costs one extra pass over the vtex_c entries. Reading is ordered by (archive, offset) so
     /// that pass stays sequential, and only the headers are parsed -- no pixels are decoded.
     /// </summary>
-    public static Sets Collect(ItemGeneratorContext ctx, IEnumerable<string> vpkPaths)
+    public static HashSet<string> Collect(ItemGeneratorContext ctx, IEnumerable<string> vpkPaths)
     {
         var package = ctx.VpkPackage;
-        if (package == null) return new Sets([], []);
+        if (package == null) return [];
 
         var work = vpkPaths
             .Select(p => (VpkPath: p, Entry: package.FindEntry(p)))
             .Where(t => t.Entry != null)
             .ToArray();
-        if (work.Length == 0) return new Sets([], []);
+        if (work.Length == 0) return [];
 
         Array.Sort(work, static (a, b) =>
         {
@@ -146,7 +140,6 @@ public static class TextureCodecPolicy
         // Entries inlined in pak01_dir.vpk (ArchiveIndex 0x7FFF) share Package.Reader's base
         // stream and seek on it, so they cannot be read concurrently.
         var dirVpkLock = new object();
-        var rawFourChannel = new ConcurrentBag<string>();
         var syntheticAlpha = new ConcurrentBag<string>();
         var po = new ParallelOptions { MaxDegreeOfParallelism = Math.Max(2, Environment.ProcessorCount) };
 
@@ -167,12 +160,10 @@ public static class TextureCodecPolicy
             using var resource = new Resource();
             resource.FileName = vpkPath;
             resource.Read(new MemoryStream(data));
-            if (IsRawFourChannelNormal(resource))
-                rawFourChannel.Add(vpkPath);
-            else if (HasSyntheticAlpha(resource))
+            if (HasSyntheticAlpha(resource))
                 syntheticAlpha.Add(vpkPath);
         });
 
-        return new Sets([.. rawFourChannel], [.. syntheticAlpha]);
+        return [.. syntheticAlpha];
     }
 }

--- a/scripts/item-generator/GameFiles/TextureCodecPolicy.cs
+++ b/scripts/item-generator/GameFiles/TextureCodecPolicy.cs
@@ -10,7 +10,14 @@ using ValveResourceFormat.ResourceTypes;
 namespace ItemGenerator.GameFiles;
 
 /// <summary>
-/// Identifies the textures whose four channels must be exported verbatim instead of
+/// Reads vtex_c headers to decide, per texture, which of its channels are real.
+///
+/// Two independent questions, both answered from the compiled header alone:
+/// <see cref="IsRawFourChannelNormal"/> asks whether VRF's HemiOct decode would destroy a
+/// channel the game stores, and <see cref="HasSyntheticAlpha"/> asks whether VRF's decode
+/// invents one the game does not.
+///
+/// The first case: the textures whose four channels must be exported verbatim instead of
 /// through ValveResourceFormat's HemiOct decode.
 ///
 /// A BC7 normal map compiled with "Mip HemiOctAnisoRoughness" and WITHOUT
@@ -43,6 +50,43 @@ public static class TextureCodecPolicy
     private const string HemiOctIsoRoughnessRgB = "Texture Compiler Version Mip HemiOctIsoRoughness_RG_B";
 
     /// <summary>
+    /// Formats that carry no alpha channel in the game data at all. Every alpha value VRF
+    /// reports for one of these is invented by its decoder, so none of it may ship.
+    ///
+    /// BC4/BC5 store one and two channels; VRF's block decoder fills the rest with 0 and the
+    /// alpha with 255. I8 is single-channel and expands to gray. DXT1 decodes through
+    /// TinyBCSharp's BC1NoAlpha, which is opaque by definition -- VRF never reads BC1's
+    /// one-bit alpha mode, so a DXT1 texture cannot reach us with alpha either.
+    ///
+    /// IA88 is deliberately absent: its second channel IS alpha. So is BC7, which is the only
+    /// block format here that can carry a genuine fourth channel.
+    /// </summary>
+    private static readonly VTexFormat[] AlphaFreeFormats =
+        [VTexFormat.ATI1N, VTexFormat.ATI2N, VTexFormat.DXT1, VTexFormat.I8];
+
+    /// <summary>
+    /// Whether every alpha value VRF will report for this texture is an artifact of its
+    /// decoder rather than data from the game.
+    ///
+    /// Two shapes reach us. The plain one is a format with fewer than four channels, where
+    /// VRF pads the alpha to 255; libwebp already drops a fully-opaque alpha, so those ship
+    /// clean today and this predicate only makes that explicit. The one that actually leaks is
+    /// a BC5 normal carrying a HemiOct dependency: <c>Decode_HemiOct</c> ends with
+    /// <c>color.a = color.b</c>, and BC5 has no blue, so 592 textures ship a fabricated
+    /// all-zero alpha plane over meaningful RGB. That is the pattern that forces `exact` on the
+    /// encoder and that silently destroys the image in any tool which premultiplies -- sharp's
+    /// own resize included.
+    ///
+    /// Gated on format alone, never on pixels: a BC7 texture whose alpha happens to be constant
+    /// still has a real fourth channel, and flipping it would change what a shader samples.
+    /// </summary>
+    public static bool HasSyntheticAlpha(Resource resource)
+    {
+        return resource.DataBlock is Texture texture
+            && Array.IndexOf(AlphaFreeFormats, texture.Format) >= 0;
+    }
+
+    /// <summary>
     /// Whether this texture's four raw channels must survive export intact.
     /// </summary>
     public static bool IsRawFourChannelNormal(Resource resource)
@@ -62,8 +106,16 @@ public static class TextureCodecPolicy
     }
 
     /// <summary>
-    /// The subset of <paramref name="vpkPaths"/> that <see cref="IsRawFourChannelNormal"/> holds
-    /// for, as normalized VPK paths.
+    /// The subsets of <paramref name="vpkPaths"/> that <see cref="IsRawFourChannelNormal"/> and
+    /// <see cref="HasSyntheticAlpha"/> hold for. Disjoint by construction: the former requires
+    /// BC7, which <see cref="AlphaFreeFormats"/> excludes.
+    /// </summary>
+    public readonly record struct Sets(
+        HashSet<string> RawFourChannelNormals,
+        HashSet<string> SyntheticAlpha);
+
+    /// <summary>
+    /// Classifies <paramref name="vpkPaths"/>, as normalized VPK paths.
     ///
     /// Deliberately re-reads the vtex_c headers rather than recording what
     /// <see cref="ResourceDecompiler"/> saw: decompilation skips textures already present in the
@@ -74,16 +126,16 @@ public static class TextureCodecPolicy
     /// Costs one extra pass over the vtex_c entries. Reading is ordered by (archive, offset) so
     /// that pass stays sequential, and only the headers are parsed -- no pixels are decoded.
     /// </summary>
-    public static HashSet<string> Collect(ItemGeneratorContext ctx, IEnumerable<string> vpkPaths)
+    public static Sets Collect(ItemGeneratorContext ctx, IEnumerable<string> vpkPaths)
     {
         var package = ctx.VpkPackage;
-        if (package == null) return [];
+        if (package == null) return new Sets([], []);
 
         var work = vpkPaths
             .Select(p => (VpkPath: p, Entry: package.FindEntry(p)))
             .Where(t => t.Entry != null)
             .ToArray();
-        if (work.Length == 0) return [];
+        if (work.Length == 0) return new Sets([], []);
 
         Array.Sort(work, static (a, b) =>
         {
@@ -94,7 +146,8 @@ public static class TextureCodecPolicy
         // Entries inlined in pak01_dir.vpk (ArchiveIndex 0x7FFF) share Package.Reader's base
         // stream and seek on it, so they cannot be read concurrently.
         var dirVpkLock = new object();
-        var found = new ConcurrentBag<string>();
+        var rawFourChannel = new ConcurrentBag<string>();
+        var syntheticAlpha = new ConcurrentBag<string>();
         var po = new ParallelOptions { MaxDegreeOfParallelism = Math.Max(2, Environment.ProcessorCount) };
 
         Parallel.ForEach(work, po, item =>
@@ -115,9 +168,11 @@ public static class TextureCodecPolicy
             resource.FileName = vpkPath;
             resource.Read(new MemoryStream(data));
             if (IsRawFourChannelNormal(resource))
-                found.Add(vpkPath);
+                rawFourChannel.Add(vpkPath);
+            else if (HasSyntheticAlpha(resource))
+                syntheticAlpha.Add(vpkPath);
         });
 
-        return [.. found];
+        return new Sets([.. rawFourChannel], [.. syntheticAlpha]);
     }
 }

--- a/scripts/item-generator/GameFiles/TextureCodecPolicy.cs
+++ b/scripts/item-generator/GameFiles/TextureCodecPolicy.cs
@@ -108,8 +108,8 @@ public static class TextureCodecPolicy
     }
 
     /// <summary>
-    /// The subset of <paramref name="vpkPaths"/>, as normalized VPK paths, that
-    /// <see cref="HasSyntheticAlpha"/> holds for.
+    /// The subsets of <paramref name="vpkPaths"/>, as normalized VPK paths, that
+    /// <see cref="IsRawFourChannelNormal"/> and <see cref="HasSyntheticAlpha"/> hold for.
     ///
     /// Deliberately re-reads the vtex_c headers rather than recording what
     /// <see cref="ResourceDecompiler"/> saw: decompilation skips textures already present in the
@@ -120,16 +120,17 @@ public static class TextureCodecPolicy
     /// Costs one extra pass over the vtex_c entries. Reading is ordered by (archive, offset) so
     /// that pass stays sequential, and only the headers are parsed -- no pixels are decoded.
     /// </summary>
-    public static HashSet<string> Collect(ItemGeneratorContext ctx, IEnumerable<string> vpkPaths)
+    public static (HashSet<string> RawFourChannelNormals, HashSet<string> SyntheticAlpha) Collect(
+        ItemGeneratorContext ctx, IEnumerable<string> vpkPaths)
     {
         var package = ctx.VpkPackage;
-        if (package == null) return [];
+        if (package == null) return ([], []);
 
         var work = vpkPaths
             .Select(p => (VpkPath: p, Entry: package.FindEntry(p)))
             .Where(t => t.Entry != null)
             .ToArray();
-        if (work.Length == 0) return [];
+        if (work.Length == 0) return ([], []);
 
         Array.Sort(work, static (a, b) =>
         {
@@ -140,6 +141,7 @@ public static class TextureCodecPolicy
         // Entries inlined in pak01_dir.vpk (ArchiveIndex 0x7FFF) share Package.Reader's base
         // stream and seek on it, so they cannot be read concurrently.
         var dirVpkLock = new object();
+        var rawFourChannelNormals = new ConcurrentBag<string>();
         var syntheticAlpha = new ConcurrentBag<string>();
         var po = new ParallelOptions { MaxDegreeOfParallelism = Math.Max(2, Environment.ProcessorCount) };
 
@@ -160,10 +162,12 @@ public static class TextureCodecPolicy
             using var resource = new Resource();
             resource.FileName = vpkPath;
             resource.Read(new MemoryStream(data));
+            if (IsRawFourChannelNormal(resource))
+                rawFourChannelNormals.Add(vpkPath);
             if (HasSyntheticAlpha(resource))
                 syntheticAlpha.Add(vpkPath);
         });
 
-        return [.. syntheticAlpha];
+        return ([.. rawFourChannelNormals], [.. syntheticAlpha]);
     }
 }


### PR DESCRIPTION
- **Drop alpha from textures whose game format has none**
- **Encode every texture with one lossy WebP path**
- **Ship whichever WebP encode is smaller per texture**
- **Encode normal maps as quantized lossless WebP**
- **Fix the null quantizeBits that encoded most textures black**
- **Quantize the alpha plane that WebP quality never reaches**
- **Spend WebP quality only where a texture measurably gains from it**
- **Decide the codec at full quality, ship the winner at a lower one**
- **Spend encoder effort only on the bytes that ship**
- **Cut encoder run time 3.6x by not paying for bytes nobody keeps**
